### PR TITLE
Assume bundles are immutable per version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ clap = { version = "4.5.21", features = ["derive", "string"] }
 reqwest = { version = "0.12.12", features = ["blocking"] }
 url = "2.5.4"
 dirs = "6.0.0"
+bytes = "1.9.0"


### PR DESCRIPTION
- Don't fiddle with etags; they're nginx <mtime>-<length> etags and
  aren't super reliable for change detection
- Just assume if we have a file at a version that that's the file; I see
  no evidence that ggg ever changes files without bumping versions
- Push smart content-addressible caching into the future list
- Return a Bytes consistently so we don't deep copy the http response.
  If the calling function decides to natively use Bytes instead of
  converting to a vec or slice, it can use the no-copy benefits, too
