### PR TITLE
Batch bundle loading/reading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1.0.137"
 polars = {version = "0.45.1", features=["csv", "lazy", "list_eval", "dtype-full"]}
 rayon = "1.10.0"
 image = { git = "https://github.com/RunDevelopment/image", branch = "new-dds-decoder" }
+iterators_extended = "0.2.0"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }

--- a/src/bin/poe_files.rs
+++ b/src/bin/poe_files.rs
@@ -4,7 +4,7 @@ use anyhow::{ensure, Context, Result};
 use clap::{ArgGroup, Parser, Subcommand};
 use glob::Pattern;
 use poe_tools::{
-    bundle_fs::{from_cdn, from_steam},
+    bundle_fs::FS,
     bundle_loader::cdn_base_url,
     commands::{
         cat::cat_file, dump_art::extract_art, dump_tables::dump_tables, extract::extract_files,
@@ -137,9 +137,9 @@ fn main() -> Result<()> {
                 Patch::Two => "2",
                 Patch::Specific(v) => v,
             };
-            from_cdn(&cdn_base_url(&cache_dir, version_string)?, &cache_dir)
+            FS::from_cdn(&cdn_base_url(&cache_dir, version_string)?, &cache_dir)
         }
-        Source::Steam { steam_folder } => from_steam(steam_folder),
+        Source::Steam { steam_folder } => FS::from_steam(steam_folder),
     }
     .context("Failed to initialise file system")?;
 

--- a/src/bundle_fs.rs
+++ b/src/bundle_fs.rs
@@ -23,35 +23,38 @@ pub struct FS {
     cache_dir: Option<PathBuf>,
 }
 
-pub fn from_steam(steam_folder: PathBuf) -> Result<FS> {
-    let index_path = steam_folder.as_path().join("Bundles2/_.index.bin");
-    let index = load_index_file(&index_path).context("Failed to load bundle index")?;
-    Ok(FS {
-        index,
-        lut: HashMap::new(),
-        steam_folder: Some(steam_folder.clone()),
-        base_url: None,
-        cache_dir: None,
-    })
-}
-pub fn from_cdn(base_url: &Url, cache_dir: &Path) -> Result<FS> {
-    let index = fetch_index_file(
-        base_url,
-        cache_dir,
-        PathBuf::from("Bundles2/_.index.bin").as_ref(),
-    )
-    .context("Failed to load bundle index")?;
-
-    Ok(FS {
-        index,
-        lut: HashMap::new(),
-        steam_folder: None,
-        base_url: Some(base_url.clone()),
-        cache_dir: Some(cache_dir.to_path_buf()),
-    })
-}
-
 impl FS {
+    /// Initialise a file system over a steam folder
+    pub fn from_steam(steam_folder: PathBuf) -> Result<FS> {
+        let index_path = steam_folder.as_path().join("Bundles2/_.index.bin");
+        let index = load_index_file(&index_path).context("Failed to load bundle index")?;
+        Ok(FS {
+            index,
+            lut: HashMap::new(),
+            steam_folder: Some(steam_folder.clone()),
+            base_url: None,
+            cache_dir: None,
+        })
+    }
+
+    /// Initialise a file system using the CDN background
+    pub fn from_cdn(base_url: &Url, cache_dir: &Path) -> Result<FS> {
+        let index = fetch_index_file(
+            base_url,
+            cache_dir,
+            PathBuf::from("Bundles2/_.index.bin").as_ref(),
+        )
+        .context("Failed to load bundle index")?;
+
+        Ok(FS {
+            index,
+            lut: HashMap::new(),
+            steam_folder: None,
+            base_url: Some(base_url.clone()),
+            cache_dir: Some(cache_dir.to_path_buf()),
+        })
+    }
+
     pub fn list(&self) -> Vec<String> {
         let mut paths = Vec::new();
         // Loop over each folder

--- a/src/bundle_fs.rs
+++ b/src/bundle_fs.rs
@@ -4,8 +4,9 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use bytes::Bytes;
+use iterators_extended::bucket::Bucket;
 use url::Url;
 
 use crate::{
@@ -78,18 +79,104 @@ impl FS {
             .flat_map(|p| parse_paths(&self.index.path_rep_bundle, p).get_paths())
     }
 
+    /// Read many files at once, optimising batch loads. Does not preserve order of paths given.
+    pub fn batch_read<'a>(
+        &'a self,
+        paths: &'a [&str],
+    ) -> impl Iterator<Item = Result<(&'a str, Bytes), (&'a str, anyhow::Error)>> {
+        // Get FileInfo's
+        let hash_builder = BuildMurmurHash64A { seed: 0x1337b33f };
+        let (fileinfos, errors) = paths
+            .iter()
+            .map(|&path| {
+                // Compute hash
+                let mut hasher = hash_builder.build_hasher();
+                hasher.write(path.to_lowercase().as_bytes());
+                let hash = hasher.finish();
+
+                // Look up the file info for this file
+                let fileinfo = self
+                    .lut
+                    .get(&hash)
+                    .map(|i| &self.index.files[*i])
+                    .with_context(|| format!("Path not found in index: {}", path))
+                    .map(|f| (path, f))
+                    .map_err(|e| (path, e));
+
+                fileinfo
+            })
+            .bucket_result();
+
+        // Batch them into their bundles
+        let fileinfos =
+            fileinfos
+                .into_iter()
+                .fold(HashMap::<_, Vec<_>>::new(), |mut acc, (path, fileinfo)| {
+                    acc.entry(fileinfo.bundle_index)
+                        .or_default()
+                        .push((path, fileinfo));
+
+                    acc
+                });
+
+        // Process files bundle-wise
+        let file_contents = fileinfos.into_iter().flat_map(|(bundle_index, files)| {
+            // Load the bundle
+            let bundle_path = format!(
+                "Bundles2/{}.bundle.bin",
+                self.index.bundles[bundle_index as usize].name
+            );
+            let bundle = if let Some(steam_folder) = &self.steam_folder {
+                let bundle_path = steam_folder.join(bundle_path);
+                load_bundle_content(&bundle_path)
+                    .with_context(|| format!("Failed to load bundle file: {:?}", bundle_path))
+            } else {
+                let bundle_path = PathBuf::from(bundle_path);
+                fetch_bundle_content(
+                    self.base_url.as_ref().unwrap(),
+                    self.cache_dir.as_ref().unwrap(),
+                    &bundle_path,
+                )
+                .with_context(|| format!("Failed to fetch bundle file: {:?}", bundle_path))
+            };
+
+            // Read the file contents - todo: see if we can do this lazily instead of
+            // collecting all files within a bundle at once
+            let contents: Vec<_> = match bundle {
+                Ok(b) => files
+                    .into_iter()
+                    .map(|(path, file)| {
+                        Ok((path, b.read_range(file.offset as usize, file.size as usize)))
+                    })
+                    .collect(),
+                Err(e) => files
+                    .into_iter()
+                    .map(|(path, _)| Err((path, anyhow!("{:?}", e))))
+                    .collect(),
+            };
+
+            contents
+        });
+
+        // Add on previous errors
+        errors.into_iter().map(Err).chain(file_contents)
+    }
+
     pub fn read(&self, path: &str) -> Result<Bytes> {
+        // Compute the hash of this file path
         let hash_builder = BuildMurmurHash64A { seed: 0x1337b33f };
         let mut hasher = hash_builder.build_hasher();
         hasher.write(path.to_lowercase().as_bytes());
         let hash = hasher.finish();
 
+        // Look up the file info for this file
         let index = self
             .lut
             .get(&hash)
             .with_context(|| format!("Path not found in index: {}", path))?;
         let file = &self.index.files[*index];
 
+        // Load the bundle
         let bundle = if let Some(steam_folder) = &self.steam_folder {
             let bundle_path = steam_folder.join(format!(
                 "Bundles2/{}.bundle.bin",

--- a/src/commands/dump_art.rs
+++ b/src/commands/dump_art.rs
@@ -13,15 +13,14 @@ pub fn extract_art(fs: &mut FS, pattern: &Pattern, output_folder: &Path) -> Resu
     );
 
     fs.list()
-        .iter()
         .filter(|filename| pattern.matches(filename))
         .map(|filename| -> Result<_, anyhow::Error> {
             // Dump it to disk
-            let contents = fs.read(filename).context("Failed to read file")?;
+            let contents = fs.read(&filename).context("Failed to read file")?;
 
             let img = image::load_from_memory(&contents).context("Failed to pares DDS image")?;
 
-            let out_filename = output_folder.join(filename).with_extension("png");
+            let out_filename = output_folder.join(&filename).with_extension("png");
             fs::create_dir_all(out_filename.parent().unwrap())
                 .context("Failed to create folder")?;
 

--- a/src/commands/dump_tables.rs
+++ b/src/commands/dump_tables.rs
@@ -338,9 +338,23 @@ pub fn dump_tables(
     // Load schema: todo: Get this from Ivy's CDN / cache it
     let schemas = fetch_schema(cache_dir).context("Failed to fetch schema file")?;
 
-    fs.list()
+    let filenames = fs
+        .list()
         .filter(|filename| pattern.matches(filename))
-        .map(|filename| -> Result<_, anyhow::Error> {
+        .collect::<Vec<_>>();
+    let filenames = filenames.iter().map(|f| f.as_str()).collect::<Vec<_>>();
+
+    fs.batch_read(&filenames)
+        // Print and filter out errors
+        .filter_map(|f| match f {
+            Ok(x) => Some(x),
+            Err((path, e)) => {
+                eprintln!("Failed to extract file: {:?}: {:?}", path, e);
+                None
+            }
+        })
+        // Attempt to read file contents
+        .map(|(filename, contents)| -> Result<_, anyhow::Error> {
             // Load table schema - todo: HashMap rather than vector
             let schema = schemas
                 .tables
@@ -350,16 +364,14 @@ pub fn dump_tables(
                 .find(|t| *t.name.to_lowercase() == *PathBuf::from(&filename).file_stem().unwrap())
                 .with_context(|| format!("Couldn't find schema for {:?}", &filename))?;
 
-            // Load the table contents
-            let contents = fs.read(&filename).context("Failed to read file")?;
-
             // Convert the data table
-            let output_path = output_folder.join(&filename).with_extension("csv");
+            let output_path = output_folder.join(filename).with_extension("csv");
             process_file(&contents, &output_path, schema)
                 .with_context(|| format!("Failed to process file: {:?}", filename))?;
 
             Ok(filename)
         })
+        // Report results
         .for_each(|result| match result {
             Ok(filename) => eprintln!("Extracted table: {}", filename),
             Err(e) => eprintln!("Failed to extract table: {:?}", e),

--- a/src/commands/dump_tables.rs
+++ b/src/commands/dump_tables.rs
@@ -339,7 +339,6 @@ pub fn dump_tables(
     let schemas = fetch_schema(cache_dir).context("Failed to fetch schema file")?;
 
     fs.list()
-        .iter()
         .filter(|filename| pattern.matches(filename))
         .map(|filename| -> Result<_, anyhow::Error> {
             // Load table schema - todo: HashMap rather than vector
@@ -348,14 +347,14 @@ pub fn dump_tables(
                 .iter()
                 // valid_for == 3 is common between both games
                 .filter(|t| t.valid_for == version || t.valid_for == 3)
-                .find(|t| *t.name.to_lowercase() == *PathBuf::from(filename).file_stem().unwrap())
-                .with_context(|| format!("Couldn't find schema for {:?}", filename))?;
+                .find(|t| *t.name.to_lowercase() == *PathBuf::from(&filename).file_stem().unwrap())
+                .with_context(|| format!("Couldn't find schema for {:?}", &filename))?;
 
             // Load the table contents
-            let contents = fs.read(filename).context("Failed to read file")?;
+            let contents = fs.read(&filename).context("Failed to read file")?;
 
             // Convert the data table
-            let output_path = output_folder.join(filename).with_extension("csv");
+            let output_path = output_folder.join(&filename).with_extension("csv");
             process_file(&contents, &output_path, schema)
                 .with_context(|| format!("Failed to process file: {:?}", filename))?;
 

--- a/src/commands/extract.rs
+++ b/src/commands/extract.rs
@@ -11,13 +11,12 @@ use crate::bundle_fs::FS;
 /// Extract files to disk matching a glob pattern
 pub fn extract_files(fs: &mut FS, pattern: &Pattern, output_folder: &Path) -> Result<()> {
     fs.list()
-        .iter()
         .filter(|filename| pattern.matches(filename))
         .map(|filename| -> Result<_, anyhow::Error> {
             // Dump it to disk
-            let contents = fs.read(filename).context("Failed to read file")?;
+            let contents = fs.read(&filename).context("Failed to read file")?;
 
-            let out_filename = output_folder.join(filename);
+            let out_filename = output_folder.join(&filename);
             fs::create_dir_all(out_filename.parent().unwrap())
                 .context("Failed to create folder")?;
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -12,7 +12,6 @@ pub fn list_files(file_system: &FS, pattern: &Pattern) -> Result<()> {
 
     file_system
         .list()
-        .iter()
         .filter(|p| pattern.matches(p))
         .try_for_each(|p| writeln!(stdout, "{}", p).context("Failed to write to stdout"))?;
 


### PR DESCRIPTION
Add a read_batch function which pre-sorts given filenames into their respective bundles first to avoid redundant loading. Current implementation is pretty messy, not a fan of the whole unwrapping/re-wrapping results stuff