### PR TITLE
Fix default globbing, add docs, fix benches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # Parsing tools for Path of Exile Bundle files
 
 # Commands
-* `list`: List the "virtual" file paths in the bundle
-* `extract`: Extract the virtual files as-is, saving them as real files to disk
-* `cat`: Dumps the binary contents of a file to stdout
-* `dump-art`: Extracts DirectDraw Surface (.dds) files and converts them to PNGs
-* `dump-tables`: Extracts data tables (.datc64), applies the [community-curated schemas](https://github.com/poe-tool-dev/dat-schema),
-and saves them out as CSVs where the schema was successfully applied.
+
+- `list`: List the "virtual" file paths in the bundle
+- `extract`: Extract the virtual files as-is, saving them as real files to disk
+- `cat`: Dumps the binary contents of a file to stdout
+- `dump-art`: Extracts DirectDraw Surface (.dds) files and converts them to PNGs
+- `dump-tables`: Extracts data tables (.datc64), applies the [community-curated schemas](https://github.com/poe-tool-dev/dat-schema),
+  and saves them out as CSVs where the schema was successfully applied.
 
 ## Usage
 
@@ -22,6 +23,21 @@ Using executable file
 poe_files --help
 ```
 
+## Globs
+
+Note that commands that take globs use the form that requires `**` to match across directory separators, e.g.
+
+```bash
+# all files in all directories (the default)
+cargo run --release --bin poe_files -- --patch 2 list '**'
+# all .datc64 files in all subdirectories
+cargo run --release --bin poe_files -- --patch 2 list '**/*.datc64'
+# all files in the art/ directory
+cargo run --release --bin poe_files -- --patch 2 list 'art/*'
+# all files in the art/ directory and its subdirectories
+cargo run --release --bin poe_files -- --patch 2 list 'art/**'
+```
+
 # Bundle File format
 
 ![bundle file format](./images/bundle_spec.png)
@@ -31,11 +47,12 @@ poe_files --help
 ![bundle index file format](./images/bundle_index_spec.png)
 
 **TODO List**
+
 - Proper documentation for the lib crate
 - Swap image.rs version once [DDS support is merged](https://github.com/image-rs/image/pull/2258)
 - Skill tree data export
 - Partially export dat tables when some schema columns fail to validate
 
-
 # Testing
+
 Tested on linux (WSL) and Windows with the Steam version of PoE 1, and rolling latest patch from the CDN for PoE 2.

--- a/benches/fs.rs
+++ b/benches/fs.rs
@@ -1,10 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use dirs::cache_dir;
-use poe_tools::{
-    bundle_fs::{from_cdn, from_steam, FS},
-    bundle_loader::cdn_base_url,
-    steam::steam_folder_search,
-};
+use poe_tools::{bundle_fs::FS, bundle_loader::cdn_base_url, steam::steam_folder_search};
 
 fn fs_benchmark_steam(c: &mut Criterion) {
     read_some_files("steam", c, steam_fs(), "data/skill*.datc64");
@@ -31,35 +27,34 @@ fn fs_load_index(c: &mut Criterion) {
     let base_url = cdn_base_url(&cache_dir, "2").expect("Failed to get base url");
     c.bench_function("load_index", |b| {
         b.iter(|| {
-            let _fs = from_cdn(&base_url, &cache_dir);
+            let _fs = FS::from_cdn(&base_url, &cache_dir);
         });
     });
 }
 
 fn steam_fs() -> FS {
-    from_steam(steam_folder_search("2").expect("Can't find steam folder"))
+    FS::from_steam(steam_folder_search("2").expect("Can't find steam folder"))
         .expect("Failed to load file system")
 }
 
 fn cdn_fs() -> FS {
     let cache_dir = cache_dir().unwrap().join("poe_data_tools");
     let base_url = cdn_base_url(&cache_dir, "2").expect("Failed to get base url");
-    from_cdn(&base_url, &cache_dir).expect("Failed to load file system")
+    FS::from_cdn(&base_url, &cache_dir).expect("Failed to load file system")
 }
 
-fn read_some_files(source: &str, c: &mut Criterion, mut fs: FS, pattern: &str) {
+fn read_some_files(source: &str, c: &mut Criterion, fs: FS, pattern: &str) {
     let glob = glob::Pattern::new(pattern).unwrap();
 
-    let list = fs.list();
+    let list: Vec<String> = fs.list().collect();
     // warm caches
     list.iter().filter(|p| glob.matches(p)).for_each(|p| {
         let _contents = fs.read(p).expect("Failed to read file");
     });
 
-    let mut list = fs.list();
     c.bench_function(format!("read_files_{}", source).as_str(), |b| {
         b.iter(|| {
-            black_box(&mut list)
+            black_box(&list)
                 .iter()
                 .filter(|p| glob.matches(p))
                 .for_each(|p| {

--- a/src/bin/poe_files.rs
+++ b/src/bin/poe_files.rs
@@ -18,7 +18,7 @@ enum Command {
     /// List files
     List {
         /// Glob patterns to filter the list of files
-        #[clap(default_value = "*")]
+        #[clap(default_value = "**")]
         #[arg(num_args = 1..)]
         globs: Vec<Pattern>,
     },
@@ -27,7 +27,7 @@ enum Command {
         /// Path to the folder to output the extracted files
         output_folder: PathBuf,
         /// Glob patterns to filter the list of files
-        #[clap(default_value = "*")]
+        #[clap(default_value = "**")]
         #[arg(num_args = 1..)]
         globs: Vec<Pattern>,
     },
@@ -42,7 +42,7 @@ enum Command {
         output_folder: PathBuf,
 
         /// Glob patterns to filter the list of files
-        #[clap(default_value = "*.datc64")]
+        #[clap(default_value = "**/*.datc64")]
         #[arg(num_args = 1..)]
         globs: Vec<Pattern>,
     },
@@ -50,7 +50,7 @@ enum Command {
         /// Path to the folder to output the extracted files
         output_folder: PathBuf,
         /// Glob pattern to filter the list of files
-        #[clap(default_value = "*.dds")]
+        #[clap(default_value = "**/*.dds")]
         #[arg(num_args = 1..)]
         globs: Vec<Pattern>,
     },


### PR DESCRIPTION
- Current globbing config needs `**` as default or it will only match
  files in the top directory, which is blank.
- Minor refactor-related syntax error fixes in the benchmarks.
- Add a section in README.md detailing Glob usage and giving examples.
