### PR TITLE
Increase flexibility of lifetime of batch_read() return

### DIFF
--- a/src/bundle_fs.rs
+++ b/src/bundle_fs.rs
@@ -82,7 +82,7 @@ impl FS {
     /// Read many files at once, optimising batch loads. Does not preserve order of paths given.
     pub fn batch_read<'a>(
         &'a self,
-        paths: &'a [&str],
+        paths: &[&'a str],
     ) -> impl Iterator<Item = Result<(&'a str, Bytes), (&'a str, anyhow::Error)>> {
         // Get FileInfo's
         let hash_builder = BuildMurmurHash64A { seed: 0x1337b33f };


### PR DESCRIPTION
I hit an issue with calling `batch_read()` while implementing a multi-tiered caching strategy externally. This seems to increase flexibility of the returned slice's lifetime and seems like it doesn't hurt anything else?

Basically making the lifetime of the slice elements equal to the lifetime of the slice, instead of shorter than it.

AI slop thinks it's more idiomatic, but I'm also trying to un-forget all the rust I ever knew at the moment.