### PR TITLE
Diff-friendly JSON export for DAT tables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ dirs = "6.0.0"
 bytes = "1.11.0"
 glob = "0.3.3"
 serde = {version = "1.0.228", features = ["derive"]}
-serde_json = "1.0.145"
+serde_json = { version = "1.0.145", features = ["preserve_order"] }
 rayon = "1.11.0"
 image = { git = "https://github.com/RunDevelopment/image", branch = "new-dds-decoder" }
 iterators_extended = "0.2.0"

--- a/src/bin/poe_data_tools.rs
+++ b/src/bin/poe_data_tools.rs
@@ -16,8 +16,8 @@ use poe_data_tools::{
 
 #[derive(Debug, Clone, ValueEnum)]
 enum DumpDatsMode {
-    CSV,
-    JSON,
+    Csv,
+    Json,
 }
 
 #[derive(Debug, Subcommand)]
@@ -48,7 +48,7 @@ enum Command {
         /// Path to write out the parsed tables to
         output_folder: PathBuf,
 
-        #[arg(long, value_enum, default_value_t = DumpDatsMode::CSV)]
+        #[arg(long, value_enum, default_value_t = DumpDatsMode::Csv)]
         mode: DumpDatsMode,
 
         /// Glob patterns to filter the list of files
@@ -195,7 +195,7 @@ fn main() -> Result<()> {
             globs,
             mode,
         } => match mode {
-            DumpDatsMode::CSV => dump_tables(
+            DumpDatsMode::Csv => dump_tables(
                 &mut fs,
                 &globs,
                 &args.cache_dir,
@@ -204,7 +204,7 @@ fn main() -> Result<()> {
             )
             .context("Dump Tables command failed")?,
 
-            DumpDatsMode::JSON => dump_tables_json::dump_tables(
+            DumpDatsMode::Json => dump_tables_json::dump_tables(
                 &mut fs,
                 &globs,
                 &args.cache_dir,

--- a/src/bin/poe_data_tools.rs
+++ b/src/bin/poe_data_tools.rs
@@ -1,17 +1,24 @@
 use std::path::PathBuf;
 
 use anyhow::{Context, Result, ensure};
-use clap::{ArgGroup, Parser, Subcommand};
+use clap::{ArgGroup, Parser, Subcommand, ValueEnum};
 use glob::Pattern;
 use poe_data_tools::{
     VERBOSE,
     bundle_fs::FS,
     bundle_loader::cdn_base_url,
     commands::{
-        Patch, cat::cat_file, dump_art::extract_art, dump_tables::dump_tables,
-        dump_trees::dump_trees, extract::extract_files, list::list_files, translate::translate,
+        Patch, cat::cat_file, dump_art::extract_art, dump_tables_csv::dump_tables,
+        dump_tables_json, dump_trees::dump_trees, extract::extract_files, list::list_files,
+        translate::translate,
     },
 };
+
+#[derive(Debug, Clone, ValueEnum)]
+enum DumpDatsMode {
+    CSV,
+    JSON,
+}
 
 #[derive(Debug, Subcommand)]
 enum Command {
@@ -40,6 +47,9 @@ enum Command {
     DumpTables {
         /// Path to write out the parsed tables to
         output_folder: PathBuf,
+
+        #[arg(long, value_enum, default_value_t = DumpDatsMode::CSV)]
+        mode: DumpDatsMode,
 
         /// Glob patterns to filter the list of files
         #[clap(default_value = "**/*.datc64")]
@@ -183,14 +193,26 @@ fn main() -> Result<()> {
         Command::DumpTables {
             output_folder,
             globs,
-        } => dump_tables(
-            &mut fs,
-            &globs,
-            &args.cache_dir,
-            &output_folder,
-            &args.patch,
-        )
-        .context("Dump Tables command failed")?,
+            mode,
+        } => match mode {
+            DumpDatsMode::CSV => dump_tables(
+                &mut fs,
+                &globs,
+                &args.cache_dir,
+                &output_folder,
+                &args.patch,
+            )
+            .context("Dump Tables command failed")?,
+
+            DumpDatsMode::JSON => dump_tables_json::dump_tables(
+                &mut fs,
+                &globs,
+                &args.cache_dir,
+                &output_folder,
+                &args.patch,
+            )
+            .context("Dump Tables command failed")?,
+        },
         Command::DumpArt {
             output_folder,
             globs,

--- a/src/bundle_loader.rs
+++ b/src/bundle_loader.rs
@@ -17,7 +17,7 @@ use winnow::{
     token::take,
 };
 
-use crate::file_parsers::shared::winnow::{TraceHelper, WinnowParser};
+use crate::file_parsers::shared::winnow::WinnowParser;
 
 pub struct CDNLoader {
     base_url: Url,
@@ -110,9 +110,10 @@ fn parse_response<'a>() -> impl WinnowParser<&'a [u8], Vec<String>> {
 }
 
 fn parse_utf16_string<'a>() -> impl WinnowParser<&'a [u8], String> {
-    length_take(le_u8.map(|l| l * 2))
-        .try_map(String::from_utf16le)
-        .trace("parse_utf16_string")
+    winnow::trace!(
+        "parse_utf16_string",
+        length_take(le_u8.map(|l| l * 2)).try_map(String::from_utf16le)
+    )
 }
 
 /// Fetch the current latest version of the game

--- a/src/commands/dump_tables_csv.rs
+++ b/src/commands/dump_tables_csv.rs
@@ -357,21 +357,12 @@ fn parse_column(
 
 /// Parse a table with the given schema into an Arrow RecordBatch
 pub fn parse_table(table: &DatFile, schema: &DatTableSchema) -> Result<RecordBatch> {
+    let column_names = schema.column_names().collect::<Vec<_>>();
+
     // Parse each of the columns
     let mut parsed_columns = vec![];
-    let mut column_names = vec![];
     let mut cur_offset = 0;
-    let mut num_unknowns = 0;
     for column in &schema.columns {
-        // Parse column name
-        let col_name = if let Some(name) = column.name.clone() {
-            name
-        } else {
-            num_unknowns += 1;
-            format!("unknown_{}", num_unknowns - 1)
-        };
-        column_names.push(col_name);
-
         // Parse column data.
         // We return out on parse failure as it may impact the interpretation of followon columns
         // if the offset is incorrect.

--- a/src/commands/dump_tables_json.rs
+++ b/src/commands/dump_tables_json.rs
@@ -134,10 +134,10 @@ fn resolve(
                 .collect::<Vec<_>>();
 
             // If there's multiple primary keys, use a list
-            if keys.len() == 1 {
-                keys[0].clone()
-            } else {
-                serde_json::to_value(keys).unwrap()
+            match keys.len() {
+                0 => serde_json::Value::Null,
+                1 => keys[0].clone(),
+                _ => serde_json::to_value(keys).unwrap(),
             }
         })
         .collect::<Vec<_>>();
@@ -149,6 +149,7 @@ fn resolve(
     // Tables with self-references need to be parsed twice
     let has_self_ref = schema.columns.iter().any(|c| c.column_type == "row");
     if has_self_ref {
+        eprintln!("Resolving self-refs table: {:?}", table);
         let parsed = {
             let mut parser = create_parser(resolved_keys, variable_section, schema);
 

--- a/src/commands/dump_tables_json.rs
+++ b/src/commands/dump_tables_json.rs
@@ -121,30 +121,34 @@ fn resolve(
             })
             .collect::<Vec<_>>()
     };
+    resolved.insert(table.to_owned(), parsed);
+    let parsed = &resolved[table];
 
     let keys_columns = schema.primary_keys().collect::<Vec<_>>();
 
-    // Try get the corresponding values for them
-    let keys = parsed
-        .iter()
-        .map(|row| {
-            let keys = keys_columns
-                .iter()
-                .map(|k| row.get(k).unwrap_or(&serde_json::Value::Null).clone())
-                .collect::<Vec<_>>();
+    if !keys_columns.is_empty() {
+        // Try get the corresponding values for them
+        let keys = parsed
+            .iter()
+            .map(|row| {
+                let keys = keys_columns
+                    .iter()
+                    .map(|k| row.get(k).unwrap_or(&serde_json::Value::Null).clone())
+                    .collect::<Vec<_>>();
 
-            // If there's multiple primary keys, use a list
-            match keys.len() {
-                0 => serde_json::Value::Null,
-                1 => keys[0].clone(),
-                _ => serde_json::to_value(keys).unwrap(),
-            }
-        })
-        .collect::<Vec<_>>();
+                // If there's multiple primary keys, use a list
+                match keys.len() {
+                    0 => unreachable!(),
+                    1 => keys[0].clone(),
+                    _ => serde_json::to_value(keys).unwrap(),
+                }
+            })
+            .collect::<Vec<_>>();
+
+        resolved_keys.insert(table.to_owned(), keys);
+    }
 
     eprintln!("Resolved table: {:?}", table);
-    resolved.insert(table.to_owned(), parsed);
-    resolved_keys.insert(table.to_owned(), keys);
 
     // Tables with self-references need to be parsed twice
     let has_self_ref = schema.columns.iter().any(|c| c.column_type == "row");

--- a/src/commands/dump_tables_json.rs
+++ b/src/commands/dump_tables_json.rs
@@ -2,7 +2,7 @@ use std::{
     collections::HashMap,
     fs::{self, File},
     io::BufWriter,
-    path::{Path, PathBuf},
+    path::Path,
 };
 
 use anyhow::{Context, Result, ensure};
@@ -10,6 +10,7 @@ use glob::{MatchOptions, Pattern};
 use winnow::Parser;
 
 use crate::{
+    VERBOSE,
     bundle_fs::FS,
     commands::Patch,
     dat::{
@@ -53,12 +54,10 @@ fn build_dependency_graph(schemas: &SchemaCollection) -> HashMap<String, Vec<Str
 
 fn resolve_enum(schema: &Enumeration) -> Vec<serde_json::Value> {
     std::iter::repeat_n(serde_json::Value::Null, schema.indexing)
-        .chain(
-            schema
-                .enumerators
-                .iter()
-                .map(|e| serde_json::to_value(e).unwrap()),
-        )
+        .chain(schema.enumerators.iter().map(|e| match e {
+            Some(value) => serde_json::Value::String(value.clone()),
+            None => serde_json::Value::Null,
+        }))
         .collect()
 }
 
@@ -71,16 +70,17 @@ fn resolve(
     deps: &HashMap<String, Vec<String>>,
     table: &str,
     version: &Patch,
-) {
+) -> anyhow::Result<()> {
     if resolved.contains_key(table) {
-        return;
+        return Ok(());
     }
 
     // Resolve children
     if let Some(table_deps) = deps.get(table) {
-        table_deps.iter().for_each(|dep| {
-            resolve(fs, schemas, resolved, resolved_keys, deps, dep, version);
-        });
+        table_deps.iter().try_for_each(|dep| {
+            resolve(fs, schemas, resolved, resolved_keys, deps, dep, version)
+                .context("Failed to resolve child table")
+        })?;
     } else {
         // NOTE: If there's no dependency entry, assume everything is a-ok (it's probably not).
         // This can happen when the schema refers to a non-existent table
@@ -88,7 +88,7 @@ fn resolve(
             "WARN: No dependency entry for table {:?}, assuming already resolved",
             table
         );
-        return;
+        return Ok(());
     }
 
     // All dependencies resolved, so resolve this one
@@ -97,17 +97,19 @@ fn resolve(
         2 => format!("data/balance/{}.datc64", table),
         _ => unreachable!("Invalid major version"),
     };
-    let bytes = fs.read(&filename).unwrap();
+    let bytes = fs.read(&filename).context("Failed to read file contents")?;
     let schema = schemas
         .tables
         .iter()
         .find(|s| s.name.eq_ignore_ascii_case(table))
-        .unwrap();
+        .context("Failed to find schema for table")?;
 
     let DatFile {
         rows,
         variable_data,
-    } = DatParser.parse(&bytes).unwrap();
+    } = DatParser
+        .parse(&bytes)
+        .context("Failed to parse dat file")?;
     // FIXME: Figure out a way to give variable section to the parser without leaking it to a
     // 'static lifetime
     let variable_section = Box::leak(Box::new(variable_data));
@@ -121,11 +123,10 @@ fn resolve(
             })
             .collect::<Vec<_>>()
     };
-    resolved.insert(table.to_owned(), parsed);
-    let parsed = &resolved[table];
+    let parsed = resolved.entry(table.to_owned()).insert_entry(parsed);
+    let parsed = parsed.get();
 
     let keys_columns = schema.primary_keys().collect::<Vec<_>>();
-
     if !keys_columns.is_empty() {
         // Try get the corresponding values for them
         let keys = parsed
@@ -140,7 +141,7 @@ fn resolve(
                 match keys.len() {
                     0 => unreachable!(),
                     1 => keys[0].clone(),
-                    _ => serde_json::to_value(keys).unwrap(),
+                    _ => serde_json::Value::Array(keys),
                 }
             })
             .collect::<Vec<_>>();
@@ -167,6 +168,8 @@ fn resolve(
 
         resolved.insert(table.to_owned(), parsed);
     }
+
+    Ok(())
 }
 
 /// Checks whether there is a cycle in the dependencies of a table
@@ -289,29 +292,46 @@ pub fn dump_tables(
         })
         .collect::<Vec<_>>();
 
-    // Resolve and extract files
-    for filename in filenames {
-        let path = PathBuf::from(filename);
-        let table_name = path.file_stem().unwrap().to_str().unwrap().to_lowercase();
+    filenames
+        .into_iter()
+        .map(|filename| -> anyhow::Result<_> {
+            let path = Path::new(&filename);
+            let table_name = path.file_stem().unwrap().to_str().unwrap().to_lowercase();
 
-        resolve(
-            fs,
-            &schemas,
-            &mut resolved,
-            &mut resolved_keys,
-            &dependencies,
-            &table_name,
-            version,
-        );
-        let json = &resolved[&table_name];
+            resolve(
+                fs,
+                &schemas,
+                &mut resolved,
+                &mut resolved_keys,
+                &dependencies,
+                &table_name,
+                version,
+            )
+            .context("Failed to resolve table")?;
+            let json = &resolved[&table_name];
 
-        // Save out
-        let output_path = output_folder.join(&path).with_added_extension("json");
-        fs::create_dir_all(output_path.parent().unwrap()).unwrap();
-        let mut out = BufWriter::new(File::create(&output_path).unwrap());
-        serde_json::to_writer_pretty(&mut out, json).unwrap();
-        eprintln!("Extracted file: {output_path:?}");
-    }
+            // Save out
+            let output_path = output_folder.join(path).with_added_extension("json");
+            fs::create_dir_all(output_path.parent().unwrap())
+                .context("Failed to create output folder")?;
+
+            let mut out =
+                BufWriter::new(File::create(&output_path).context("Failed to create output file")?);
+            serde_json::to_writer_pretty(&mut out, json).context("Failed to serialize json")?;
+
+            Ok(filename)
+        })
+        .for_each(|result| match result {
+            Ok(filename) => eprintln!("Extracted file: {}", filename),
+            Err(e) => {
+                let error_message = if *VERBOSE.get().unwrap() {
+                    format!("{e:?}")
+                } else {
+                    format!("{e}")
+                };
+                eprintln!("Failed to extract file: {error_message}");
+            }
+        });
 
     Ok(())
 }

--- a/src/commands/dump_tables_json.rs
+++ b/src/commands/dump_tables_json.rs
@@ -1,0 +1,312 @@
+use std::{
+    collections::HashMap,
+    fs::{self, File},
+    io::BufWriter,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result, ensure};
+use glob::{MatchOptions, Pattern};
+use winnow::Parser;
+
+use crate::{
+    bundle_fs::FS,
+    commands::Patch,
+    dat::{
+        ivy_schema::{Enumeration, SchemaCollection, fetch_schema},
+        parser::create_parser,
+    },
+    file_parsers::{
+        FileParser,
+        dat::{DatParser, types::DatFile},
+    },
+};
+
+fn build_dependency_graph(schemas: &SchemaCollection) -> HashMap<String, Vec<String>> {
+    // Tables
+    let mut dependencies = schemas
+        .tables
+        .iter()
+        .map(|s| {
+            let deps = s
+                .columns
+                .iter()
+                .filter(|c| c.column_type == "foreignrow" || c.column_type == "enumrow")
+                .filter_map(|c| c.references.as_ref())
+                .map(|r| r.table.to_lowercase())
+                .collect();
+
+            (s.name.to_lowercase(), deps)
+        })
+        .collect::<HashMap<_, _>>();
+
+    // Enums
+    dependencies.extend(
+        schemas
+            .enumerations
+            .iter()
+            .map(|e| (e.name.to_lowercase(), vec![])),
+    );
+
+    dependencies
+}
+
+fn resolve_enum(schema: &Enumeration) -> Vec<serde_json::Value> {
+    std::iter::repeat_n(serde_json::Value::Null, schema.indexing)
+        .chain(
+            schema
+                .enumerators
+                .iter()
+                .map(|e| serde_json::to_value(e).unwrap()),
+        )
+        .collect()
+}
+
+/// Recursively resolve a table and its dependencies
+fn resolve(
+    fs: &mut FS,
+    schemas: &SchemaCollection,
+    resolved: &mut HashMap<String, Vec<serde_json::Value>>,
+    resolved_keys: &mut HashMap<String, Vec<serde_json::Value>>,
+    deps: &HashMap<String, Vec<String>>,
+    table: &str,
+    version: &Patch,
+) {
+    if resolved.contains_key(table) {
+        return;
+    }
+
+    // Resolve children
+    if let Some(table_deps) = deps.get(table) {
+        table_deps.iter().for_each(|dep| {
+            resolve(fs, schemas, resolved, resolved_keys, deps, dep, version);
+        });
+    } else {
+        // NOTE: If there's no dependency entry, assume everything is a-ok (it's probably not).
+        // This can happen when the schema refers to a non-existent table
+        eprintln!(
+            "WARN: No dependency entry for table {:?}, assuming already resolved",
+            table
+        );
+        return;
+    }
+
+    // All dependencies resolved, so resolve this one
+    let filename = match version.major() {
+        1 => format!("data/{}.datc64", table),
+        2 => format!("data/balance/{}.datc64", table),
+        _ => unreachable!("Invalid major version"),
+    };
+    let bytes = fs.read(&filename).unwrap();
+    let schema = schemas
+        .tables
+        .iter()
+        .find(|s| s.name.eq_ignore_ascii_case(table))
+        .unwrap();
+
+    let DatFile {
+        rows,
+        variable_data,
+    } = DatParser.parse(&bytes).unwrap();
+    // FIXME: Figure out a way to give variable section to the parser without leaking it to a
+    // 'static lifetime
+    let variable_section = Box::leak(Box::new(variable_data));
+    let parsed = {
+        let mut parser = create_parser(resolved_keys, variable_section, schema);
+
+        rows.iter()
+            .map(|row| match parser.parse(row) {
+                Ok(key_vals) => key_vals,
+                Err(_) => serde_json::Value::Null,
+            })
+            .collect::<Vec<_>>()
+    };
+
+    let keys_columns = schema.primary_keys().collect::<Vec<_>>();
+
+    // Try get the corresponding values for them
+    let keys = parsed
+        .iter()
+        .map(|row| {
+            let keys = keys_columns
+                .iter()
+                .map(|k| row.get(k).unwrap_or(&serde_json::Value::Null).clone())
+                .collect::<Vec<_>>();
+
+            // If there's multiple primary keys, use a list
+            if keys.len() == 1 {
+                keys[0].clone()
+            } else {
+                serde_json::to_value(keys).unwrap()
+            }
+        })
+        .collect::<Vec<_>>();
+
+    eprintln!("Resolved table: {:?}", table);
+    resolved.insert(table.to_owned(), parsed);
+    resolved_keys.insert(table.to_owned(), keys);
+
+    // Tables with self-references need to be parsed twice
+    let has_self_ref = schema.columns.iter().any(|c| c.column_type == "row");
+    if has_self_ref {
+        let parsed = {
+            let mut parser = create_parser(resolved_keys, variable_section, schema);
+
+            rows.iter()
+                .map(|row| match parser.parse(row) {
+                    Ok(key_vals) => key_vals,
+                    Err(_) => serde_json::Value::Null,
+                })
+                .collect::<Vec<_>>()
+        };
+
+        resolved.insert(table.to_owned(), parsed);
+    }
+}
+
+/// Checks whether there is a cycle in the dependencies of a table
+fn has_cycle<'a>(
+    deps: &'a HashMap<String, Vec<String>>,
+    table: &'a str,
+    seen: &mut Vec<&'a str>,
+) -> bool {
+    if seen.contains(&table) {
+        return true;
+    }
+    seen.push(table);
+
+    if let Some(children) = deps.get(table)
+        && children.iter().any(|c| has_cycle(deps, c, seen))
+    {
+        return true;
+    }
+    seen.pop();
+
+    false
+}
+
+pub fn dump_tables(
+    fs: &mut FS,
+    patterns: &[Pattern],
+    cache_dir: &Path,
+    output_folder: &Path,
+    version: &Patch,
+) -> Result<()> {
+    for pattern in patterns {
+        ensure!(
+            pattern.as_str().ends_with(".datc64"),
+            "Only .datc64 table export is supported."
+        );
+    }
+
+    let schemas = fetch_schema(cache_dir)
+        .context("Failed to fetch schema file")?
+        .filter_version(version);
+
+    // Remove tables that don't exist in the index
+    // This happens when the schema is out of sync
+    let schemas = SchemaCollection {
+        tables: schemas
+            .tables
+            .iter()
+            .filter(|s| {
+                let filename = match version.major() {
+                    1 => format!("data/{}.datc64", s.name),
+                    2 => format!("data/balance/{}.datc64", s.name),
+                    _ => unreachable!("Invalid major version"),
+                };
+
+                // Check that this file can be read
+                let res = fs.read(&filename);
+                if res.is_err() {
+                    eprintln!("WARN: File not in index: {}", filename);
+                }
+
+                res.is_ok()
+            })
+            .cloned()
+            .collect(),
+        enumerations: schemas.enumerations.clone(),
+    };
+
+    // Build dependency graph
+    let mut dependencies = build_dependency_graph(&schemas);
+
+    // Remove ones with cycles
+    let cycles = dependencies
+        .keys()
+        .filter(|t| has_cycle(&dependencies, t, &mut vec![]))
+        .cloned()
+        .collect::<Vec<_>>();
+    for t in cycles {
+        dependencies.remove(&t);
+        eprintln!("Skipping table due to cycle: {:?}", t);
+    }
+
+    let mut resolved = HashMap::new();
+    let mut resolved_keys = HashMap::new();
+
+    // Resolve enums first as they have no dependencies
+    schemas.enumerations.iter().for_each(|e| {
+        let e_resolved = resolve_enum(e);
+        let name = e.name.to_lowercase();
+        resolved.insert(name.clone(), e_resolved.clone());
+        resolved_keys.insert(name, e_resolved);
+    });
+
+    // Filter list of files we're going to extract
+    let filenames = fs
+        .list()
+        // Filter on glob
+        .filter(|filename| {
+            patterns.iter().any(|pattern| {
+                pattern.matches_with(
+                    filename,
+                    MatchOptions {
+                        require_literal_separator: true,
+                        ..Default::default()
+                    },
+                )
+            })
+        })
+        // Skip files we can't process
+        .filter(|filename| {
+            let path = Path::new(filename);
+            let table_name = path.file_stem().unwrap().to_str().unwrap().to_lowercase();
+
+            let keep = dependencies.contains_key(&table_name);
+
+            if !keep {
+                eprintln!("Skipping {:?}, schema not found", path);
+            }
+
+            keep
+        })
+        .collect::<Vec<_>>();
+
+    // Resolve and extract files
+    for filename in filenames {
+        let path = PathBuf::from(filename);
+        let table_name = path.file_stem().unwrap().to_str().unwrap().to_lowercase();
+
+        resolve(
+            fs,
+            &schemas,
+            &mut resolved,
+            &mut resolved_keys,
+            &dependencies,
+            &table_name,
+            version,
+        );
+        let json = &resolved[&table_name];
+
+        // Save out
+        let output_path = output_folder.join(&path).with_added_extension("json");
+        fs::create_dir_all(output_path.parent().unwrap()).unwrap();
+        let mut out = BufWriter::new(File::create(&output_path).unwrap());
+        serde_json::to_writer_pretty(&mut out, json).unwrap();
+        eprintln!("Extracted file: {output_path:?}");
+    }
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod cat;
 pub mod dump_art;
-pub mod dump_tables;
+pub mod dump_tables_csv;
+pub mod dump_tables_json;
 pub mod dump_trees;
 pub mod extract;
 pub mod list;

--- a/src/dat/ivy_schema.rs
+++ b/src/dat/ivy_schema.rs
@@ -97,6 +97,18 @@ pub struct ColumnSchema {
     pub interval: bool,
 }
 
+impl ColumnSchema {
+    /// Whether this column refers to another schema
+    pub fn is_ref(&self) -> bool {
+        matches!(self.column_type.as_str(), "row" | "foreignrow" | "enumrow")
+    }
+
+    /// Whether this column is a collection of multiple values
+    pub fn is_multi(&self) -> bool {
+        self.array || self.interval
+    }
+}
+
 #[derive(Deserialize, Debug, Clone)]
 pub struct References {
     pub table: String,

--- a/src/dat/ivy_schema.rs
+++ b/src/dat/ivy_schema.rs
@@ -3,12 +3,48 @@ use std::{fs, path::Path};
 use anyhow::Result;
 use serde::Deserialize;
 
-#[derive(Deserialize, Debug)]
+use crate::commands::Patch;
+
+#[derive(Deserialize, Debug, Clone)]
 pub struct SchemaCollection {
     pub tables: Vec<DatTableSchema>,
+    pub enumerations: Vec<Enumeration>,
 }
 
-#[derive(Deserialize, Debug)]
+impl SchemaCollection {
+    /// Filter the schemas for the given game version
+    pub fn filter_version(&self, version: &Patch) -> Self {
+        let version = version.major();
+
+        Self {
+            tables: self
+                .tables
+                .iter()
+                .filter(|t| t.valid_for == version || t.valid_for == 3)
+                .cloned()
+                .collect(),
+
+            enumerations: self
+                .enumerations
+                .iter()
+                .filter(|e| e.valid_for == version || e.valid_for == 3)
+                .cloned()
+                .collect(),
+        }
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
+pub struct Enumeration {
+    #[serde(rename = "validFor")]
+    pub valid_for: u32,
+    /// Table name
+    pub name: String,
+    pub indexing: usize,
+    pub enumerators: Vec<Option<String>>,
+}
+
+#[derive(Deserialize, Debug, Clone)]
 pub struct DatTableSchema {
     /// PoE Version
     /// 1 - PoE 1
@@ -21,7 +57,31 @@ pub struct DatTableSchema {
     pub columns: Vec<ColumnSchema>,
 }
 
-#[derive(Deserialize, Debug)]
+impl DatTableSchema {
+    /// Iterate over column names, generating names for unknown columns
+    pub fn column_names(&self) -> impl Iterator<Item = String> {
+        self.columns.iter().scan(0_usize, |num_unknowns, c| {
+            if let Some(name) = &c.name {
+                Some(name.clone())
+            } else {
+                let name = format!("unknown_{}", num_unknowns);
+                *num_unknowns += 1;
+                Some(name)
+            }
+        })
+    }
+
+    /// Iterate over all columns marked unique in the schema
+    pub fn primary_keys(&self) -> impl Iterator<Item = String> {
+        self.columns
+            .iter()
+            .zip(self.column_names())
+            .filter(|(c, _)| c.unique)
+            .map(|(_, name)| name)
+    }
+}
+
+#[derive(Deserialize, Debug, Clone)]
 pub struct ColumnSchema {
     pub name: Option<String>,
     pub description: Option<String>,
@@ -37,7 +97,7 @@ pub struct ColumnSchema {
     pub interval: bool,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Debug, Clone)]
 pub struct References {
     pub table: String,
 }

--- a/src/dat/mod.rs
+++ b/src/dat/mod.rs
@@ -1,2 +1,3 @@
 pub mod ivy_schema;
+pub mod parser;
 pub mod table_view;

--- a/src/dat/parser.rs
+++ b/src/dat/parser.rs
@@ -109,14 +109,27 @@ fn plain_column<'a>(
 
 /// Foreign/self references, enums, and arrays of them
 ///
+///  Return values:
+///  null   // Null scalar index
+///  []     // Empty array / interval
 ///  {
-///      "TableName": "...",
-///      Id: "...",              // Scalar
+///      "TableName": "...",     // Known target table
+///      "TableName": null,      // Unknown target table
+///
+///      Id: "...",              // Scalar with good target index, single-key target
+///      Id: ["..."],            // Scalar with good target index, multi-key target
+///      "RowIndex": 12345       // Scalar with bad index / no target table
+///
 ///      Ids: [                  // Array / interval
 ///          "...",              // Single-key target
 ///          ["...", "..."],     // Multi-key target
 ///          {"rowIndex": 123},  // Bad index / no target keys
-///          null,               // Null index (should only happen for scalars)
+///          null,               // Null index (technically possible but shouldn't appear in an array)
+///      ]
+///
+///      "RowIndices": [         // Array / interval with no target table
+///         12345,
+///         131235,
 ///      ]
 ///  }
 ///
@@ -144,9 +157,14 @@ fn ref_column<'a>(
                 return Ok(Value::Null);
             };
 
+            // If the table it refers to is known
             let value = if let Some(table_name) = table_name
+                // And that table exists
                 && let Some(keys) = resolved_keys.get(&table_name.to_lowercase())
+                // And the row it refers to exists
                 && let Some(key) = keys.get(row)
+                // And that row has a primary key
+                && !key.is_null()
             {
                 key.clone()
             } else {
@@ -194,15 +212,36 @@ fn ref_column<'a>(
             (true, true) => unreachable!(),
         };
 
-        let out = if ids.is_null() {
-            Value::Null
-        } else {
-            let id_key = if ids.is_array() { "Ids" } else { "Id" };
-
-            json!({
+        let out = match ids {
+            // For scalar null refs, collapse to null
+            Value::Null => Value::Null,
+            Value::Array(values) => {
+                if values.is_empty() {
+                    // For empty array of refs, collapse to []
+                    Value::Array(vec![])
+                } else {
+                    let ids_key = if column.is_multi() {
+                        // Array
+                        "Ids"
+                    } else {
+                        // Scalar with multi-key
+                        "Id"
+                    };
+                    json!({
+                        "TableName": table_name,
+                        ids_key: values,
+                    })
+                }
+            }
+            Value::Bool(_) | Value::Number(_) | Value::String(_) => json!({
                 "TableName": table_name,
-                id_key: ids,
-            })
+                "Id": ids,
+            }),
+            Value::Object(_) => {
+                // Scalar row index or foreign ref
+
+                ids
+            }
         };
 
         Ok(out)
@@ -219,13 +258,11 @@ pub fn create_parser<'a>(
         let mut out = Map::new();
 
         for (column, column_name) in schema.columns.iter().zip(schema.column_names()) {
-            let res = dispatch! {
-                empty.value(column.column_type.as_str());
-                "row" | "enumrow" | "foreignrow" => ref_column(column, variable_section, resolved_keys),
-                "string" | "u32" | "i32" | "f32" | "u16" | "i16" | "bool" | "array" => plain_column(column, variable_section),
-                _ => fail,
-            }
-            .parse_next(input);
+            let res = if column.is_ref() {
+                ref_column(column, variable_section, resolved_keys).parse_next(input)
+            } else {
+                plain_column(column, variable_section).parse_next(input)
+            };
 
             if let Ok(item) = res {
                 out.insert(column_name, item);

--- a/src/dat/parser.rs
+++ b/src/dat/parser.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use serde_json::{Number, Value, map::Map};
+use serde_json::{Number, Value, json, map::Map};
 use winnow::{
     Parser,
     binary::{le_f32, le_i16, le_i32, le_u8, le_u16, le_u32, le_u64, le_u128},
@@ -81,75 +81,55 @@ fn plain_column<'a>(
 }
 
 /// Foreign/self references, enums, and arrays of them
+///
+///  {
+///      "TableName": "...",
+///      Id: "...",              // Scalar
+///      Ids: [                  // Array / interval
+///          "...",              // Single-key target
+///          ["...", "..."],     // Multi-key target
+///          {"rowIndex": 123},  // Bad index / no target keys
+///          null,               // Null index (shouldn't happen in list)
+///      ]
+///  }
+///
 fn ref_column<'a>(
     column: &ColumnSchema,
     variable_section: &'static [u8],
     resolved_keys: &HashMap<String, Vec<Value>>,
 ) -> impl WinnowParser<&'a [u8], Value> {
     move |input: &mut &[u8]| -> winnow::Result<_> {
-        let table_name = if let Some(table_name) = &column.references {
-            table_name.table.as_str()
-        } else {
-            ""
+        let table_name = column.references.as_ref().map(|r| &r.table);
+
+        let mut item_parser = |input: &mut &[u8]| -> winnow::Result<_> {
+            let row = dispatch! {
+                empty.value(column.column_type.as_str());
+                "foreignrow" => le_u128
+                    .map(|r| (r != 0xfefefefe_fefefefe_fefefefe_fefefefe).then_some(r as usize)),
+                "row" => le_u64.map(|r| (r != 0xfefefefe_fefefefe).then_some(r as usize)),
+                // Enums are non-nullable
+                "enumrow" => le_u32.map(|r| Some(r as usize)),
+                _ => fail,
+            }
+            .parse_next(input)?;
+
+            let Some(row) = row else {
+                return Ok(Value::Null);
+            };
+
+            let value = if let Some(table_name) = table_name
+                && let Some(keys) = resolved_keys.get(&table_name.to_lowercase())
+                && let Some(key) = keys.get(row)
+            {
+                key.clone()
+            } else {
+                json!({"RowIndex": row})
+            };
+
+            Ok(value)
         };
 
-        let mut item_parser = dispatch! {
-            empty.value(column.column_type.as_str());
-
-            "foreignrow" => le_u128.map(move |row| {
-                if row == u128::from_le_bytes([0xfe; 16]) {
-                    Value::Null
-                } else {
-                    let mut value = Map::new();
-                    value.insert("TableName".to_owned(), Value::String(table_name.to_owned()));
-                    value.insert("RowIndex".to_owned(), Value::Number(Number::from_u128(row).unwrap()));
-
-                    if let Some(keys) = resolved_keys.get(&table_name.to_lowercase())
-                    && let Some(key) = keys.get(row as usize) {
-                        value.insert("Key".to_owned(), key.clone());
-                    }
-
-                    Value::Object(value)
-                }
-            }),
-
-            // NOTE: Tables with self references need to be resolved twice. Once to initialise
-            // non-reference columns, second to resolve self-references
-            "row" => le_u64.map(move |row| {
-                if row == u64::from_le_bytes([0xfe; 8]) {
-                    Value::Null
-                } else {
-                    let mut value = Map::new();
-                    value.insert("TableName".to_owned(), Value::String(table_name.to_owned()));
-                    value.insert("RowIndex".to_owned(), Value::Number(Number::from(row)));
-
-                    if let Some(keys) = resolved_keys.get(&table_name.to_lowercase())
-                    && let Some(key) = keys.get(row as usize) {
-                        value.insert("Key".to_owned(), key.clone());
-                    }
-
-                    Value::Object(value)
-                }
-            }),
-
-            "enumrow" => le_u32.map(move |row| {
-                if let Some(table) = resolved_keys.get(&table_name.to_lowercase())
-                    && let Some(e) = table.get(row as usize)
-                {
-                    e.clone()
-                } else {
-                    let mut value = Map::new();
-                    value.insert("TableName".to_owned(), Value::String(table_name.to_owned()));
-                    value.insert("RowIndex".to_owned(), Value::Number(Number::from(row)));
-                    Value::Object(value)
-                }
-            }),
-
-            _ => fail,
-
-        };
-
-        let out = match (column.array, column.interval) {
+        let ids = match (column.array, column.interval) {
             // Array
             (true, false) => {
                 let (length, pointer) = (
@@ -175,6 +155,13 @@ fn ref_column<'a>(
             (false, false) => item_parser.parse_next(input)?,
             (true, true) => unreachable!(),
         };
+
+        let id_key = if ids.is_array() { "Ids" } else { "Id" };
+
+        let out = json!({
+            "TableName": table_name,
+            id_key: ids,
+        });
 
         Ok(out)
     }

--- a/src/dat/parser.rs
+++ b/src/dat/parser.rs
@@ -99,16 +99,8 @@ pub fn create_parser<'a>(
                 "i16" => le_i16.map(|x| serde_json::to_value(x).unwrap() ),
 
                 "bool" => le_u8
-                            .try_map(|b| {
-                                let b = match b {
-                                    0 => false,
-                                    1 => true,
-                                    _ => return Err(ContextError::new()),
-                                };
-                                Ok(b)
-                            })
-                            .map(serde_json::Value::Bool),
-
+                    .verify_map(|b| (b <= 2).then_some(b == 1))
+                    .map(serde_json::Value::Bool),
 
                 _ => fail,
 

--- a/src/dat/parser.rs
+++ b/src/dat/parser.rs
@@ -107,6 +107,74 @@ fn plain_column<'a>(
     }
 }
 
+enum ResolvedRef {
+    Null,
+    Valid(Value),
+    // Row index
+    Invalid(usize),
+}
+
+enum ResolvedRefColumn {
+    Scalar(ResolvedRef),
+    Multi(Vec<ResolvedRef>),
+}
+
+impl ResolvedRefColumn {
+    fn serialise(&self, table_name: Option<&str>, has_keys: bool) -> Value {
+        match self {
+            ResolvedRefColumn::Scalar(resolved_ref) => match resolved_ref {
+                ResolvedRef::Null => Value::Null,
+                ResolvedRef::Valid(value) => json!({
+                    "TableName": table_name,
+                    "Id": value
+                }),
+                ResolvedRef::Invalid(row) => json!({
+                    "TableName": table_name,
+                    "RowIndex": row
+                }),
+            },
+            ResolvedRefColumn::Multi(resolved_refs) => {
+                if resolved_refs.is_empty() {
+                    Value::Array(vec![])
+                } else if has_keys {
+                    let ids = resolved_refs
+                        .iter()
+                        .map(|r| match r {
+                            ResolvedRef::Null => {
+                                unreachable!("There shouldn't be any null references in an array")
+                            }
+                            ResolvedRef::Valid(value) => value.clone(),
+                            ResolvedRef::Invalid(row) => json!({
+                                "RowIndex": row
+                            }),
+                        })
+                        .collect::<Vec<_>>();
+
+                    json!({
+                        "TableName": table_name,
+                        "Ids": ids
+                    })
+                } else {
+                    let indices = resolved_refs
+                        .iter()
+                        .map(|r| {
+                            let ResolvedRef::Invalid(row) = r else {
+                                unreachable!("All refs should be invalid if target has no keys");
+                            };
+                            *row
+                        })
+                        .collect::<Vec<_>>();
+
+                    json!({
+                        "TableName": table_name,
+                        "RowIndices": indices
+                    })
+                }
+            }
+        }
+    }
+}
+
 /// Foreign/self references, enums, and arrays of them
 ///
 ///  Return values:
@@ -139,9 +207,10 @@ fn ref_column<'a>(
     resolved_keys: &HashMap<String, Vec<Value>>,
 ) -> impl WinnowParser<&'a [u8], Value> {
     move |input: &mut &[u8]| -> winnow::Result<_> {
-        let table_name = column.references.as_ref().map(|r| &r.table);
+        let target_table = column.references.as_ref().map(|r| r.table.as_str());
+        let target_keys = target_table.and_then(|name| resolved_keys.get(&name.to_lowercase()));
 
-        let mut item_parser = |input: &mut &[u8]| -> winnow::Result<_> {
+        let mut ref_parser = |input: &mut &[u8]| -> winnow::Result<_> {
             let row = dispatch! {
                 empty.value(column.column_type.as_str());
                 "foreignrow" => le_u128
@@ -154,27 +223,25 @@ fn ref_column<'a>(
             .parse_next(input)?;
 
             let Some(row) = row else {
-                return Ok(Value::Null);
+                return Ok(ResolvedRef::Null);
             };
 
-            // If the table it refers to is known
-            let value = if let Some(table_name) = table_name
-                // And that table exists
-                && let Some(keys) = resolved_keys.get(&table_name.to_lowercase())
+            // If the target table has keys
+            let value = if let Some(keys) = target_keys
                 // And the row it refers to exists
                 && let Some(key) = keys.get(row)
                 // And that row has a primary key
                 && !key.is_null()
             {
-                key.clone()
+                ResolvedRef::Valid(key.clone())
             } else {
-                json!({"RowIndex": row})
+                ResolvedRef::Invalid(row)
             };
 
             Ok(value)
         };
 
-        let ids = match (column.array, column.interval) {
+        let refs = match (column.array, column.interval) {
             // Array
             (true, false) => {
                 let (length, pointer) = (
@@ -196,83 +263,25 @@ fn ref_column<'a>(
 
                 let mut input = &variable_section[pointer as usize - 8..];
 
-                let items = std::iter::repeat_with(|| item_parser.parse_next(&mut input))
+                let items = std::iter::repeat_with(|| ref_parser.parse_next(&mut input))
                     .take(length as usize)
                     .collect::<winnow::Result<Vec<_>>>()?;
 
-                Value::Array(items)
+                ResolvedRefColumn::Multi(items)
             }
             // Interval
-            (false, true) => Value::Array(vec![
-                item_parser.parse_next(input)?,
-                item_parser.parse_next(input)?,
+            (false, true) => ResolvedRefColumn::Multi(vec![
+                ref_parser.parse_next(input)?,
+                ref_parser.parse_next(input)?,
             ]),
             // Scalar
-            (false, false) => item_parser.parse_next(input)?,
+            (false, false) => ResolvedRefColumn::Scalar(ref_parser.parse_next(input)?),
             (true, true) => unreachable!(),
         };
 
-        let out = match ids {
-            // For scalar null refs, collapse to null
-            Value::Null => Value::Null,
-            Value::Array(values) => {
-                if values.is_empty() {
-                    // For empty array of refs, collapse to []
-                    Value::Array(vec![])
-                } else {
-                    let mut map = Map::new();
-                    map.insert(
-                        "TableName".to_owned(),
-                        serde_json::to_value(table_name).unwrap(),
-                    );
+        let serialised = refs.serialise(target_table, target_keys.is_some());
 
-                    // Target table has key
-                    if let Some(table_name) = table_name
-                        && resolved_keys.contains_key(&table_name.to_lowercase())
-                    {
-                        let ids_key = if column.is_multi() {
-                            // Array
-                            "Ids"
-                        } else {
-                            // Scalar with multi-key
-                            "Id"
-                        };
-
-                        map.insert(ids_key.to_owned(), Value::Array(values));
-                    } else {
-                        // Row indices into unknown table
-                        let indices = values
-                            .into_iter()
-                            .map(|v| {
-                                let Value::Object(mut map) = v else {
-                                    unreachable!("Got {v:?}");
-                                };
-                                let Some(row) = map.remove("RowIndex") else {
-                                    unreachable!()
-                                };
-
-                                row
-                            })
-                            .collect::<Vec<_>>();
-
-                        map.insert("RowIndices".to_owned(), Value::Array(indices));
-                    }
-
-                    Value::Object(map)
-                }
-            }
-            Value::Bool(_) | Value::Number(_) | Value::String(_) => json!({
-                "TableName": table_name,
-                "Id": ids,
-            }),
-            Value::Object(_) => {
-                // Scalar row index or foreign ref
-
-                ids
-            }
-        };
-
-        Ok(out)
+        Ok(serialised)
     }
 }
 

--- a/src/dat/parser.rs
+++ b/src/dat/parser.rs
@@ -42,16 +42,24 @@ fn plain_column<'a>(
 
             "string" => string(variable_section).map(|x| serde_json::to_value(x).unwrap()),
 
-            "u32" => le_u32.map(|x| Value::Number(Number::from(x)) ),
-            "i32" => le_i32.map(|x| Value::Number(Number::from(x)) ),
-            "f32" => le_f32.map(|x| serde_json::to_value(x).unwrap() ),
+            "u32" => le_u32.map(|x| Value::Number(Number::from(x))),
+            "i32" => le_i32.map(|x| Value::Number(Number::from(x))),
+            "f32" => le_f32.map(|x| serde_json::to_value(x).unwrap()),
 
-            "u16" => le_u16.map(|x| Value::Number(Number::from(x)) ),
-            "i16" => le_i16.map(|x| Value::Number(Number::from(x)) ),
+            "u16" => le_u16.map(|x| Value::Number(Number::from(x))),
+            "i16" => le_i16.map(|x| Value::Number(Number::from(x))),
 
-            "bool" => le_u8
-                .verify_map(|b| (b <= 2).then_some(b == 1))
-                .map(Value::Bool),
+            "bool" => le_u8.map(|b|
+                            if b <= 2 {
+                                Some(b == 1)
+                            } else {
+                                eprintln!("WARN: Bad value for bool: {b}");
+                                None
+                            }
+                        )
+                        .map(|x| serde_json::to_value(x).unwrap()),
+
+            "array" => empty.value(Value::Null),
 
             _ => fail,
         };
@@ -61,9 +69,20 @@ fn plain_column<'a>(
             (true, false) => {
                 let (length, pointer) = (
                     le_u64,
-                    le_u64.verify(|offset| (8..variable_section.len() as u64 + 8).contains(offset)),
+                    le_u64.map(|offset| {
+                        if (8..variable_section.len() as u64 + 8).contains(&offset) {
+                            Some(offset)
+                        } else {
+                            eprintln!("WARN: Array pointer out of bounds: {offset}");
+                            None
+                        }
+                    }),
                 )
                     .parse_next(input)?;
+
+                let Some(pointer) = pointer else {
+                    return Ok(Value::Null);
+                };
 
                 let mut input = &variable_section[pointer as usize - 8..];
 
@@ -141,9 +160,20 @@ fn ref_column<'a>(
             (true, false) => {
                 let (length, pointer) = (
                     le_u64,
-                    le_u64.verify(|offset| (8..variable_section.len() as u64 + 8).contains(offset)),
+                    le_u64.map(|offset| {
+                        if (8..variable_section.len() as u64 + 8).contains(&offset) {
+                            Some(offset)
+                        } else {
+                            eprintln!("WARN: Array pointer out of bounds: {offset}");
+                            None
+                        }
+                    }),
                 )
                     .parse_next(input)?;
+
+                let Some(pointer) = pointer else {
+                    return Ok(Value::Null);
+                };
 
                 let mut input = &variable_section[pointer as usize - 8..];
 
@@ -189,14 +219,33 @@ pub fn create_parser<'a>(
 
         for (column, column_name) in schema.columns.iter().zip(schema.column_names()) {
             let column_name = &column_name;
-            let item = dispatch! {
+
+            let res = dispatch! {
                 empty.value(column.column_type.as_str());
                 "row" | "enumrow" | "foreignrow" => ref_column(column, variable_section, resolved_keys),
-                "string" | "u32" | "i32" | "f32" | "u16" | "i16" | "bool" => plain_column(column, variable_section),
+                "string" | "u32" | "i32" | "f32" | "u16" | "i16" | "bool" | "array" => plain_column(column, variable_section),
                 _ => fail,
             }
-            .parse_next(input)?;
-            out.insert(column_name.to_owned(), item);
+            .parse_next(input);
+
+            if let Ok(item) = res {
+                out.insert(column_name.to_owned(), item);
+            } else {
+                // NOTE: All the item parsers should pass with null on error, so an error here should
+                //  be unrecoverable. Return items parsed up until now instead of losing whole
+                //  row.
+                eprintln!(
+                    "WARN: Error applying schema for {:?} {:?}, bytes left: {:?}",
+                    schema.name,
+                    column,
+                    input.len(),
+                );
+                break;
+            }
+        }
+
+        if !input.is_empty() {
+            eprintln!("WARN: Extra bytes left after applying schema");
         }
 
         Ok(Value::Object(out))

--- a/src/dat/parser.rs
+++ b/src/dat/parser.rs
@@ -6,6 +6,7 @@ use winnow::{
     binary::{le_f32, le_i16, le_i32, le_u8, le_u16, le_u32, le_u64, le_u128},
     combinator::{dispatch, empty, fail},
     error::ContextError,
+    token::rest,
 };
 
 use crate::{
@@ -218,8 +219,6 @@ pub fn create_parser<'a>(
         let mut out = Map::new();
 
         for (column, column_name) in schema.columns.iter().zip(schema.column_names()) {
-            let column_name = &column_name;
-
             let res = dispatch! {
                 empty.value(column.column_type.as_str());
                 "row" | "enumrow" | "foreignrow" => ref_column(column, variable_section, resolved_keys),
@@ -229,7 +228,7 @@ pub fn create_parser<'a>(
             .parse_next(input);
 
             if let Ok(item) = res {
-                out.insert(column_name.to_owned(), item);
+                out.insert(column_name, item);
             } else {
                 // NOTE: All the item parsers should pass with null on error, so an error here should
                 //  be unrecoverable. Return items parsed up until now instead of losing whole
@@ -245,7 +244,12 @@ pub fn create_parser<'a>(
         }
 
         if !input.is_empty() {
-            eprintln!("WARN: Extra bytes left after applying schema");
+            eprintln!(
+                "WARN: Extra bytes left after applying schema: {:?}",
+                input.len(),
+            );
+
+            let _rest = rest(input)?;
         }
 
         Ok(Value::Object(out))

--- a/src/dat/parser.rs
+++ b/src/dat/parser.rs
@@ -1,0 +1,158 @@
+use std::collections::HashMap;
+
+use serde_json::map::Map;
+use winnow::{
+    Parser,
+    binary::{le_f32, le_i16, le_i32, le_u8, le_u16, le_u32, le_u64, le_u128},
+    combinator::{dispatch, empty, fail},
+    error::ContextError,
+};
+
+use crate::{
+    dat::{ivy_schema::DatTableSchema, table_view::take_utf16_string},
+    file_parsers::shared::winnow::WinnowParser,
+};
+
+/// Read an index and read a string out of the variable section starting at the index
+fn string<'a>(variable_section: &[u8]) -> impl WinnowParser<&'a [u8], String> {
+    let vs_len = variable_section.len();
+    le_u64
+        .verify(move |offset| (8..vs_len as u64 + 8).contains(offset))
+        .map(move |offset| take_utf16_string(&variable_section[offset as usize - 8..]))
+}
+
+/// Creates a winnow parser from a schema which can then be applied to the bytes of the dat table
+pub fn create_parser<'a>(
+    resolved_keys: &HashMap<String, Vec<serde_json::Value>>,
+    variable_section: &'static [u8],
+    schema: &DatTableSchema,
+) -> impl Parser<&'a [u8], serde_json::Value, ContextError> {
+    move |input: &mut &[u8]| {
+        let mut out = Map::new();
+
+        for (column, column_name) in schema.columns.iter().zip(schema.column_names()) {
+            let table_name = if let Some(table_name) = &column.references {
+                table_name.table.as_str()
+            } else {
+                ""
+            };
+
+            let mut item_parser = dispatch! {
+                empty.value(column.column_type.as_str());
+
+                "foreignrow" => le_u128.map(move |row| {
+                    if row == u128::from_le_bytes([0xfe; 16]) {
+                        serde_json::Value::Null
+                    } else {
+                        let mut value = Map::new();
+                        value.insert("TableName".to_owned(), serde_json::to_value(table_name).unwrap());
+                        value.insert("RowIndex".to_owned(), serde_json::to_value(row).unwrap());
+
+                        if let Some(keys) = resolved_keys.get(&table_name.to_lowercase())
+                        && let Some(key) = keys.get(row as usize) {
+                            value.insert("Key".to_owned(), key.clone());
+                        }
+
+                        serde_json::Value::Object(value)
+                    }
+                }),
+
+                // NOTE: Tables with self references need to be resolved twice. Once to initialise
+                // non-reference columns, second to resolve self-references
+                "row" => le_u64.map(move |row| {
+                    if row == u64::from_le_bytes([0xfe; 8]) {
+                        serde_json::Value::Null
+                    } else {
+                        let mut value = Map::new();
+                        value.insert("TableName".to_owned(), serde_json::to_value(table_name).unwrap());
+                        value.insert("RowIndex".to_owned(), serde_json::to_value(row).unwrap());
+
+                        if let Some(keys) = resolved_keys.get(&table_name.to_lowercase())
+                        && let Some(key) = keys.get(row as usize) {
+                            value.insert("Key".to_owned(), key.clone());
+                        }
+
+                        serde_json::Value::Object(value)
+                    }
+                }),
+
+                "enumrow" => le_u32.map(move |row| {
+                    if let Some(table) = resolved_keys.get(&table_name.to_lowercase())
+                        && let Some(e) = table.get(row as usize)
+                    {
+                        e.clone()
+                    } else {
+                        let mut value = Map::new();
+                        value.insert("TableName".to_owned(), serde_json::to_value(table_name).unwrap());
+                        value.insert("RowIndex".to_owned(), serde_json::to_value(row).unwrap());
+                        serde_json::Value::Object(value)
+                    }
+                }),
+
+                "string" => string(variable_section).map(serde_json::Value::String),
+
+                "u32" => le_u32.map(|x| serde_json::to_value(x).unwrap() ),
+                "i32" => le_i32.map(|x| serde_json::to_value(x).unwrap() ),
+                "f32" => le_f32.map(|x| serde_json::to_value(x).unwrap() ),
+
+                "u16" => le_u16.map(|x| serde_json::to_value(x).unwrap() ),
+                "i16" => le_i16.map(|x| serde_json::to_value(x).unwrap() ),
+
+                "bool" => le_u8
+                            .try_map(|b| {
+                                let b = match b {
+                                    0 => false,
+                                    1 => true,
+                                    _ => return Err(ContextError::new()),
+                                };
+                                Ok(b)
+                            })
+                            .map(serde_json::Value::Bool),
+
+
+                _ => fail,
+
+            };
+
+            match (column.array, column.interval) {
+                // Array
+                (true, false) => {
+                    let (length, pointer) = (
+                        le_u64,
+                        le_u64.verify(|offset| {
+                            (8..variable_section.len() as u64 + 8).contains(offset)
+                        }),
+                    )
+                        .parse_next(input)?;
+
+                    let mut input = &variable_section[pointer as usize - 8..];
+
+                    let mut items = vec![];
+                    for _ in 0..length {
+                        let item = item_parser.parse_next(&mut input)?;
+                        items.push(item);
+                    }
+
+                    out.insert(column_name, serde_json::to_value(items).unwrap());
+                }
+                // Interval
+                (false, true) => {
+                    let values = vec![
+                        item_parser.parse_next(input)?,
+                        item_parser.parse_next(input)?,
+                    ];
+
+                    out.insert(column_name, serde_json::to_value(values).unwrap());
+                }
+                // Scalar
+                (false, false) => {
+                    let value = item_parser.parse_next(input)?;
+                    out.insert(column_name, serde_json::to_value(value).unwrap());
+                }
+                (true, true) => unreachable!(),
+            }
+        }
+
+        Ok(serde_json::Value::Object(out))
+    }
+}

--- a/src/dat/parser.rs
+++ b/src/dat/parser.rs
@@ -17,11 +17,18 @@ use crate::{
 };
 
 /// Read an index and read a string out of the variable section starting at the index
-fn string<'a>(variable_section: &[u8]) -> impl WinnowParser<&'a [u8], String> {
+/// Returns null instead of erroring if a bad offset is found
+fn string<'a>(variable_section: &[u8]) -> impl WinnowParser<&'a [u8], Option<String>> {
     let vs_len = variable_section.len();
-    le_u64
-        .verify(move |offset| (8..vs_len as u64 + 8).contains(offset))
-        .map(move |offset| take_utf16_string(&variable_section[offset as usize - 8..]))
+    le_u64.map(move |offset| {
+        if (8..vs_len as u64 + 8).contains(&offset) {
+            let string = take_utf16_string(&variable_section[offset as usize - 8..]);
+            Some(string)
+        } else {
+            eprintln!("WARN: Bad offset for string {offset}");
+            None
+        }
+    })
 }
 
 /// Basic data types & arrays of them
@@ -33,7 +40,7 @@ fn plain_column<'a>(
         let mut item_parser = dispatch! {
             empty.value(column.column_type.as_str());
 
-            "string" => string(variable_section).map(Value::String),
+            "string" => string(variable_section).map(|x| serde_json::to_value(x).unwrap()),
 
             "u32" => le_u32.map(|x| Value::Number(Number::from(x)) ),
             "i32" => le_i32.map(|x| Value::Number(Number::from(x)) ),

--- a/src/dat/parser.rs
+++ b/src/dat/parser.rs
@@ -89,7 +89,7 @@ fn plain_column<'a>(
 ///          "...",              // Single-key target
 ///          ["...", "..."],     // Multi-key target
 ///          {"rowIndex": 123},  // Bad index / no target keys
-///          null,               // Null index (shouldn't happen in list)
+///          null,               // Null index (should only happen for scalars)
 ///      ]
 ///  }
 ///
@@ -156,12 +156,16 @@ fn ref_column<'a>(
             (true, true) => unreachable!(),
         };
 
-        let id_key = if ids.is_array() { "Ids" } else { "Id" };
+        let out = if ids.is_null() {
+            Value::Null
+        } else {
+            let id_key = if ids.is_array() { "Ids" } else { "Id" };
 
-        let out = json!({
-            "TableName": table_name,
-            id_key: ids,
-        });
+            json!({
+                "TableName": table_name,
+                id_key: ids,
+            })
+        };
 
         Ok(out)
     }

--- a/src/dat/parser.rs
+++ b/src/dat/parser.rs
@@ -123,7 +123,7 @@ fn plain_column<'a>(
 ///      Ids: [                  // Array / interval
 ///          "...",              // Single-key target
 ///          ["...", "..."],     // Multi-key target
-///          {"rowIndex": 123},  // Bad index / no target keys
+///          {"rowIndex": 123},  // Bad index
 ///          null,               // Null index (technically possible but shouldn't appear in an array)
 ///      ]
 ///
@@ -220,17 +220,45 @@ fn ref_column<'a>(
                     // For empty array of refs, collapse to []
                     Value::Array(vec![])
                 } else {
-                    let ids_key = if column.is_multi() {
-                        // Array
-                        "Ids"
+                    let mut map = Map::new();
+                    map.insert(
+                        "TableName".to_owned(),
+                        serde_json::to_value(table_name).unwrap(),
+                    );
+
+                    // Target table has key
+                    if let Some(table_name) = table_name
+                        && resolved_keys.contains_key(&table_name.to_lowercase())
+                    {
+                        let ids_key = if column.is_multi() {
+                            // Array
+                            "Ids"
+                        } else {
+                            // Scalar with multi-key
+                            "Id"
+                        };
+
+                        map.insert(ids_key.to_owned(), Value::Array(values));
                     } else {
-                        // Scalar with multi-key
-                        "Id"
-                    };
-                    json!({
-                        "TableName": table_name,
-                        ids_key: values,
-                    })
+                        // Row indices into unknown table
+                        let indices = values
+                            .into_iter()
+                            .map(|v| {
+                                let Value::Object(mut map) = v else {
+                                    unreachable!("Got {v:?}");
+                                };
+                                let Some(row) = map.remove("RowIndex") else {
+                                    unreachable!()
+                                };
+
+                                row
+                            })
+                            .collect::<Vec<_>>();
+
+                        map.insert("RowIndices".to_owned(), Value::Array(indices));
+                    }
+
+                    Value::Object(map)
                 }
             }
             Value::Bool(_) | Value::Number(_) | Value::String(_) => json!({

--- a/src/dat/parser.rs
+++ b/src/dat/parser.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use serde_json::map::Map;
+use serde_json::{Number, Value, map::Map};
 use winnow::{
     Parser,
     binary::{le_f32, le_i16, le_i32, le_u8, le_u16, le_u32, le_u64, le_u128},
@@ -9,7 +9,10 @@ use winnow::{
 };
 
 use crate::{
-    dat::{ivy_schema::DatTableSchema, table_view::take_utf16_string},
+    dat::{
+        ivy_schema::{ColumnSchema, DatTableSchema},
+        table_view::take_utf16_string,
+    },
     file_parsers::shared::winnow::WinnowParser,
 };
 
@@ -21,130 +24,183 @@ fn string<'a>(variable_section: &[u8]) -> impl WinnowParser<&'a [u8], String> {
         .map(move |offset| take_utf16_string(&variable_section[offset as usize - 8..]))
 }
 
+/// Basic data types & arrays of them
+fn plain_column<'a>(
+    column: &ColumnSchema,
+    variable_section: &'static [u8],
+) -> impl WinnowParser<&'a [u8], Value> {
+    move |input: &mut &[u8]| -> winnow::Result<_> {
+        let mut item_parser = dispatch! {
+            empty.value(column.column_type.as_str());
+
+            "string" => string(variable_section).map(Value::String),
+
+            "u32" => le_u32.map(|x| Value::Number(Number::from(x)) ),
+            "i32" => le_i32.map(|x| Value::Number(Number::from(x)) ),
+            "f32" => le_f32.map(|x| serde_json::to_value(x).unwrap() ),
+
+            "u16" => le_u16.map(|x| Value::Number(Number::from(x)) ),
+            "i16" => le_i16.map(|x| Value::Number(Number::from(x)) ),
+
+            "bool" => le_u8
+                .verify_map(|b| (b <= 2).then_some(b == 1))
+                .map(Value::Bool),
+
+            _ => fail,
+        };
+
+        let out = match (column.array, column.interval) {
+            // Array
+            (true, false) => {
+                let (length, pointer) = (
+                    le_u64,
+                    le_u64.verify(|offset| (8..variable_section.len() as u64 + 8).contains(offset)),
+                )
+                    .parse_next(input)?;
+
+                let mut input = &variable_section[pointer as usize - 8..];
+
+                let items = std::iter::repeat_with(|| item_parser.parse_next(&mut input))
+                    .take(length as usize)
+                    .collect::<winnow::Result<Vec<_>>>()?;
+
+                Value::Array(items)
+            }
+            // Interval
+            (false, true) => Value::Array(vec![
+                item_parser.parse_next(input)?,
+                item_parser.parse_next(input)?,
+            ]),
+            // Scalar
+            (false, false) => item_parser.parse_next(input)?,
+            (true, true) => unreachable!(),
+        };
+
+        Ok(out)
+    }
+}
+
+/// Foreign/self references, enums, and arrays of them
+fn ref_column<'a>(
+    column: &ColumnSchema,
+    variable_section: &'static [u8],
+    resolved_keys: &HashMap<String, Vec<Value>>,
+) -> impl WinnowParser<&'a [u8], Value> {
+    move |input: &mut &[u8]| -> winnow::Result<_> {
+        let table_name = if let Some(table_name) = &column.references {
+            table_name.table.as_str()
+        } else {
+            ""
+        };
+
+        let mut item_parser = dispatch! {
+            empty.value(column.column_type.as_str());
+
+            "foreignrow" => le_u128.map(move |row| {
+                if row == u128::from_le_bytes([0xfe; 16]) {
+                    Value::Null
+                } else {
+                    let mut value = Map::new();
+                    value.insert("TableName".to_owned(), Value::String(table_name.to_owned()));
+                    value.insert("RowIndex".to_owned(), Value::Number(Number::from_u128(row).unwrap()));
+
+                    if let Some(keys) = resolved_keys.get(&table_name.to_lowercase())
+                    && let Some(key) = keys.get(row as usize) {
+                        value.insert("Key".to_owned(), key.clone());
+                    }
+
+                    Value::Object(value)
+                }
+            }),
+
+            // NOTE: Tables with self references need to be resolved twice. Once to initialise
+            // non-reference columns, second to resolve self-references
+            "row" => le_u64.map(move |row| {
+                if row == u64::from_le_bytes([0xfe; 8]) {
+                    Value::Null
+                } else {
+                    let mut value = Map::new();
+                    value.insert("TableName".to_owned(), Value::String(table_name.to_owned()));
+                    value.insert("RowIndex".to_owned(), Value::Number(Number::from(row)));
+
+                    if let Some(keys) = resolved_keys.get(&table_name.to_lowercase())
+                    && let Some(key) = keys.get(row as usize) {
+                        value.insert("Key".to_owned(), key.clone());
+                    }
+
+                    Value::Object(value)
+                }
+            }),
+
+            "enumrow" => le_u32.map(move |row| {
+                if let Some(table) = resolved_keys.get(&table_name.to_lowercase())
+                    && let Some(e) = table.get(row as usize)
+                {
+                    e.clone()
+                } else {
+                    let mut value = Map::new();
+                    value.insert("TableName".to_owned(), Value::String(table_name.to_owned()));
+                    value.insert("RowIndex".to_owned(), Value::Number(Number::from(row)));
+                    Value::Object(value)
+                }
+            }),
+
+            _ => fail,
+
+        };
+
+        let out = match (column.array, column.interval) {
+            // Array
+            (true, false) => {
+                let (length, pointer) = (
+                    le_u64,
+                    le_u64.verify(|offset| (8..variable_section.len() as u64 + 8).contains(offset)),
+                )
+                    .parse_next(input)?;
+
+                let mut input = &variable_section[pointer as usize - 8..];
+
+                let items = std::iter::repeat_with(|| item_parser.parse_next(&mut input))
+                    .take(length as usize)
+                    .collect::<winnow::Result<Vec<_>>>()?;
+
+                Value::Array(items)
+            }
+            // Interval
+            (false, true) => Value::Array(vec![
+                item_parser.parse_next(input)?,
+                item_parser.parse_next(input)?,
+            ]),
+            // Scalar
+            (false, false) => item_parser.parse_next(input)?,
+            (true, true) => unreachable!(),
+        };
+
+        Ok(out)
+    }
+}
+
 /// Creates a winnow parser from a schema which can then be applied to the bytes of the dat table
 pub fn create_parser<'a>(
-    resolved_keys: &HashMap<String, Vec<serde_json::Value>>,
+    resolved_keys: &HashMap<String, Vec<Value>>,
     variable_section: &'static [u8],
     schema: &DatTableSchema,
-) -> impl Parser<&'a [u8], serde_json::Value, ContextError> {
+) -> impl Parser<&'a [u8], Value, ContextError> {
     move |input: &mut &[u8]| {
         let mut out = Map::new();
 
         for (column, column_name) in schema.columns.iter().zip(schema.column_names()) {
-            let table_name = if let Some(table_name) = &column.references {
-                table_name.table.as_str()
-            } else {
-                ""
-            };
-
-            let mut item_parser = dispatch! {
+            let column_name = &column_name;
+            let item = dispatch! {
                 empty.value(column.column_type.as_str());
-
-                "foreignrow" => le_u128.map(move |row| {
-                    if row == u128::from_le_bytes([0xfe; 16]) {
-                        serde_json::Value::Null
-                    } else {
-                        let mut value = Map::new();
-                        value.insert("TableName".to_owned(), serde_json::to_value(table_name).unwrap());
-                        value.insert("RowIndex".to_owned(), serde_json::to_value(row).unwrap());
-
-                        if let Some(keys) = resolved_keys.get(&table_name.to_lowercase())
-                        && let Some(key) = keys.get(row as usize) {
-                            value.insert("Key".to_owned(), key.clone());
-                        }
-
-                        serde_json::Value::Object(value)
-                    }
-                }),
-
-                // NOTE: Tables with self references need to be resolved twice. Once to initialise
-                // non-reference columns, second to resolve self-references
-                "row" => le_u64.map(move |row| {
-                    if row == u64::from_le_bytes([0xfe; 8]) {
-                        serde_json::Value::Null
-                    } else {
-                        let mut value = Map::new();
-                        value.insert("TableName".to_owned(), serde_json::to_value(table_name).unwrap());
-                        value.insert("RowIndex".to_owned(), serde_json::to_value(row).unwrap());
-
-                        if let Some(keys) = resolved_keys.get(&table_name.to_lowercase())
-                        && let Some(key) = keys.get(row as usize) {
-                            value.insert("Key".to_owned(), key.clone());
-                        }
-
-                        serde_json::Value::Object(value)
-                    }
-                }),
-
-                "enumrow" => le_u32.map(move |row| {
-                    if let Some(table) = resolved_keys.get(&table_name.to_lowercase())
-                        && let Some(e) = table.get(row as usize)
-                    {
-                        e.clone()
-                    } else {
-                        let mut value = Map::new();
-                        value.insert("TableName".to_owned(), serde_json::to_value(table_name).unwrap());
-                        value.insert("RowIndex".to_owned(), serde_json::to_value(row).unwrap());
-                        serde_json::Value::Object(value)
-                    }
-                }),
-
-                "string" => string(variable_section).map(serde_json::Value::String),
-
-                "u32" => le_u32.map(|x| serde_json::to_value(x).unwrap() ),
-                "i32" => le_i32.map(|x| serde_json::to_value(x).unwrap() ),
-                "f32" => le_f32.map(|x| serde_json::to_value(x).unwrap() ),
-
-                "u16" => le_u16.map(|x| serde_json::to_value(x).unwrap() ),
-                "i16" => le_i16.map(|x| serde_json::to_value(x).unwrap() ),
-
-                "bool" => le_u8
-                    .verify_map(|b| (b <= 2).then_some(b == 1))
-                    .map(serde_json::Value::Bool),
-
+                "row" | "enumrow" | "foreignrow" => ref_column(column, variable_section, resolved_keys),
+                "string" | "u32" | "i32" | "f32" | "u16" | "i16" | "bool" => plain_column(column, variable_section),
                 _ => fail,
-
-            };
-
-            match (column.array, column.interval) {
-                // Array
-                (true, false) => {
-                    let (length, pointer) = (
-                        le_u64,
-                        le_u64.verify(|offset| {
-                            (8..variable_section.len() as u64 + 8).contains(offset)
-                        }),
-                    )
-                        .parse_next(input)?;
-
-                    let mut input = &variable_section[pointer as usize - 8..];
-
-                    let mut items = vec![];
-                    for _ in 0..length {
-                        let item = item_parser.parse_next(&mut input)?;
-                        items.push(item);
-                    }
-
-                    out.insert(column_name, serde_json::to_value(items).unwrap());
-                }
-                // Interval
-                (false, true) => {
-                    let values = vec![
-                        item_parser.parse_next(input)?,
-                        item_parser.parse_next(input)?,
-                    ];
-
-                    out.insert(column_name, serde_json::to_value(values).unwrap());
-                }
-                // Scalar
-                (false, false) => {
-                    let value = item_parser.parse_next(input)?;
-                    out.insert(column_name, serde_json::to_value(value).unwrap());
-                }
-                (true, true) => unreachable!(),
             }
+            .parse_next(input)?;
+            out.insert(column_name.to_owned(), item);
         }
 
-        Ok(serde_json::Value::Object(out))
+        Ok(Value::Object(out))
     }
 }

--- a/src/dat/table_view.rs
+++ b/src/dat/table_view.rs
@@ -25,7 +25,10 @@ impl DatFile {
     pub fn view_col(&self, offset: usize, width: usize) -> Result<impl Iterator<Item = &[u8]>> {
         ensure!(
             offset + width <= self.width(),
-            "Requested column out of bounds"
+            "Requested column out of bounds: bytes {}-{}, row width: {}",
+            offset,
+            offset + width,
+            self.width(),
         );
         let iter = self
             .rows

--- a/src/dat/table_view.rs
+++ b/src/dat/table_view.rs
@@ -5,7 +5,7 @@ use anyhow::{Context, Result, ensure};
 use crate::file_parsers::dat::types::DatFile;
 
 // Take a null-terminated UTF-16 string
-fn take_utf16_string(input: &[u8]) -> String {
+pub fn take_utf16_string(input: &[u8]) -> String {
     let u16_data = input
         .chunks_exact(2)
         .map(|c| u16::from_le_bytes(c.try_into().unwrap()))

--- a/src/file_parsers/amd/parser.rs
+++ b/src/file_parsers/amd/parser.rs
@@ -3,7 +3,7 @@ use winnow::{
     Parser,
     ascii::{dec_uint, float, space1},
     binary::length_repeat,
-    combinator::{cond, dispatch, empty, fail, opt, preceded as P, repeat, trace},
+    combinator::{cond, dispatch, empty, fail, opt, preceded as P, repeat},
     token::literal,
 };
 
@@ -29,7 +29,7 @@ fn animation_stage<'a>() -> impl SliceParser<'a, &'a str, AnimationStage> {
 }
 
 fn bone_rotation<'a>(num_coords: usize) -> impl WinnowParser<&'a str, BoneRotation> {
-    trace("bone_rotation", move |input: &mut &str| {
+    winnow::trace!("bone_rotation", move |input: &mut &str| {
         let bone = quoted_str(input)?;
 
         let coord_order = P(space1, unquoted_str).parse_next(input)?;
@@ -51,7 +51,7 @@ fn bone_rotation<'a>(num_coords: usize) -> impl WinnowParser<&'a str, BoneRotati
 }
 
 fn bone_rotations<'a>() -> impl SliceParser<'a, &'a str, Vec<BoneRotation>> {
-    trace("bone_rotations", |input: &mut &[&str]| {
+    winnow::trace!("bone_rotations", |input: &mut &[&str]| {
         let (num_rotations, num_coords): (usize, Option<usize>) =
             lift((dec_uint, opt(P(space1, dec_uint)))).parse_next(input)?;
 

--- a/src/file_parsers/amd/parser.rs
+++ b/src/file_parsers/amd/parser.rs
@@ -11,19 +11,21 @@ use super::types::*;
 use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
     winnow::{
-        TraceHelper, WinnowParser, nullable_uint, quoted_str, repeat_array, separated_array,
-        unquoted_str, version_line,
+        WinnowParser, nullable_uint, quoted_str, repeat_array, separated_array, unquoted_str,
+        version_line,
     },
 };
 
 fn animation_stage<'a>() -> impl SliceParser<'a, &'a str, AnimationStage> {
-    (
-        lift(quoted_str), //
-        lift(dec_uint),
-        lift(separated_array(space1, float)),
+    winnow::trace!(
+        "animation_stage",
+        (
+            lift(quoted_str), //
+            lift(dec_uint),
+            lift(separated_array(space1, float)),
+        )
+            .map(|(name, time, floats)| AnimationStage { name, time, floats })
     )
-        .map(|(name, time, floats)| AnimationStage { name, time, floats })
-        .trace("animation_stage")
 }
 
 fn bone_rotation<'a>(num_coords: usize) -> impl WinnowParser<&'a str, BoneRotation> {
@@ -64,43 +66,38 @@ fn bone_rotations<'a>() -> impl SliceParser<'a, &'a str, Vec<BoneRotation>> {
 }
 
 fn floats<'a>() -> impl WinnowParser<&'a str, Vec<f32>> {
-    length_repeat(
-        dec_uint::<_, u32, _>, //
-        P(space1, float::<_, f32, _>),
+    winnow::trace!(
+        "floats",
+        length_repeat(
+            dec_uint::<_, u32, _>, //
+            P(space1, float::<_, f32, _>),
+        )
     )
-    .trace("floats")
 }
 
 fn group<'a>(version: u32) -> impl SliceParser<'a, &'a str, Group> {
-    (
-        lift(quoted_str),
-        lift(unquoted_str),
-        lift(dec_uint),
-        length_repeat(
-            lift(dec_uint::<_, u32, _>), //
-            animation_stage(),
-        ),
-        dispatch! {
-            empty.value(version);
-            1 => empty.value(None),
-            2 => opt(lift(floats())),
-            3.. => lift(floats()).map(Some),
-            _ => fail,
-        },
-        cond(version >= 4, bone_rotations()),
-        opt(repeat_array(lift(nullable_uint()))),
-    )
-        .map(
-            |(
-                name,
-                animation_type,
-                animation_time,
-                animation_stages,
-                float_group,
-                bone_rotations,
-                extra_ints,
-            )| {
-                Group {
+    winnow::trace!(
+        "group",
+        (
+            lift(quoted_str),
+            lift(unquoted_str),
+            lift(dec_uint),
+            length_repeat(
+                lift(dec_uint::<_, u32, _>), //
+                animation_stage(),
+            ),
+            dispatch! {
+                empty.value(version);
+                1 => empty.value(None),
+                2 => opt(lift(floats())),
+                3.. => lift(floats()).map(Some),
+                _ => fail,
+            },
+            cond(version >= 4, bone_rotations()),
+            opt(repeat_array(lift(nullable_uint()))),
+        )
+            .map(
+                |(
                     name,
                     animation_type,
                     animation_time,
@@ -108,36 +105,49 @@ fn group<'a>(version: u32) -> impl SliceParser<'a, &'a str, Group> {
                     float_group,
                     bone_rotations,
                     extra_ints,
-                }
-            },
-        )
-        .trace("group")
+                )| {
+                    Group {
+                        name,
+                        animation_type,
+                        animation_time,
+                        animation_stages,
+                        float_group,
+                        bone_rotations,
+                        extra_ints,
+                    }
+                },
+            )
+    )
 }
 
 fn bone_group<'a>() -> impl WinnowParser<&'a str, BoneGroup> {
-    (
-        quoted_str, //
-        P(
-            space1,
-            length_repeat(
-                dec_uint::<_, u32, _>, //
-                P(space1, quoted_str),
+    winnow::trace!(
+        "bone_group",
+        (
+            quoted_str, //
+            P(
+                space1,
+                length_repeat(
+                    dec_uint::<_, u32, _>, //
+                    P(space1, quoted_str),
+                ),
             ),
-        ),
+        )
+            .map(|(name, bones)| BoneGroup { name, bones })
     )
-        .map(|(name, bones)| BoneGroup { name, bones })
-        .trace("bone_group")
 }
 
 fn bone_groups<'a>() -> impl SliceParser<'a, &'a str, Vec<BoneGroup>> {
-    length_repeat(
-        lift(P(
-            (literal("BoneGroups"), space1), //
-            dec_uint::<_, u32, _>,
-        )), //
-        lift(bone_group()),
+    winnow::trace!(
+        "bone_groups",
+        length_repeat(
+            lift(P(
+                (literal("BoneGroups"), space1), //
+                dec_uint::<_, u32, _>,
+            )), //
+            lift(bone_group()),
+        )
     )
-    .trace("bone_groups")
 }
 
 pub fn parse_amd_str(contents: &str) -> Result<AMDFile> {

--- a/src/file_parsers/ao/mod.rs
+++ b/src/file_parsers/ao/mod.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use parser::parse_ao_str;
 use types::*;
 
-use crate::file_parsers::{shared::utf16_bom_to_string, FileParser};
+use crate::file_parsers::{FileParser, shared::utf16_bom_to_string};
 
 pub struct AOParser;
 

--- a/src/file_parsers/ao/parser.rs
+++ b/src/file_parsers/ao/parser.rs
@@ -4,59 +4,64 @@ use winnow::{
     ascii::space1,
     combinator::{alt, delimited, opt, preceded as P, repeat},
     token::literal,
-    trace_name,
 };
 
 use super::types::*;
 use crate::file_parsers::shared::winnow::{
-    TraceHelper, WinnowParser, quoted_str, single_quoted_str, spaces_or_comments, unquoted_str,
+    WinnowParser, quoted_str, single_quoted_str, spaces_or_comments, unquoted_str,
     version_line,
 };
 
 fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
-    (
-        unquoted_str,
-        (spaces_or_comments(), literal("="), spaces_or_comments()),
-        alt((quoted_str, single_quoted_str, unquoted_str)),
+    winnow::trace!(
+        "entry",
+        (
+            unquoted_str,
+            (spaces_or_comments(), literal("="), spaces_or_comments()),
+            alt((quoted_str, single_quoted_str, unquoted_str)),
+        )
+            .map(|(key, _, value)| Entry { key, value })
     )
-        .map(|(key, _, value)| Entry { key, value })
-        .trace(trace_name!("entry"))
 }
 
 fn parse_struct<'a>() -> impl WinnowParser<&'a str, Struct> {
-    (
-        unquoted_str,
-        delimited(
-            P(opt(spaces_or_comments()), literal("{")),
-            repeat(0.., P(spaces_or_comments(), entry())),
-            P(opt(spaces_or_comments()), literal("}")),
-        ),
+    winnow::trace!(
+        "struct",
+        (
+            unquoted_str,
+            delimited(
+                P(opt(spaces_or_comments()), literal("{")),
+                repeat(0.., P(spaces_or_comments(), entry())),
+                P(opt(spaces_or_comments()), literal("}")),
+            ),
+        )
+            .map(|(name, entries)| Struct { name, entries })
     )
-        .map(|(name, entries)| Struct { name, entries })
-        .trace(trace_name!("struct"))
 }
 
 pub fn parse_ao_str(contents: &str) -> Result<AOFile> {
-    let mut parser = (
-        version_line(),
-        opt(P(spaces_or_comments(), literal("abstract"))),
-        repeat::<_, _, Vec<_>, _, _>(
-            1..,
-            P(
-                (spaces_or_comments(), literal("extends"), space1),
-                quoted_str,
+    let mut parser = winnow::trace!(
+        "ao_file",
+        (
+            version_line(),
+            opt(P(spaces_or_comments(), literal("abstract"))),
+            repeat::<_, _, Vec<_>, _, _>(
+                1..,
+                P(
+                    (spaces_or_comments(), literal("extends"), space1),
+                    quoted_str,
+                ),
             ),
-        ),
-        repeat(0.., P(spaces_or_comments(), parse_struct())),
-        opt(spaces_or_comments()),
-    )
-        .map(|(version, is_abstract, extends, structs, _)| AOFile {
-            version,
-            is_abstract: is_abstract.is_some(),
-            extends: extends.into_iter().filter(|e| e == "nothing").collect(),
-            structs,
-        })
-        .trace(trace_name!("ao_file"));
+            repeat(0.., P(spaces_or_comments(), parse_struct())),
+            opt(spaces_or_comments()),
+        )
+            .map(|(version, is_abstract, extends, structs, _)| AOFile {
+                version,
+                is_abstract: is_abstract.is_some(),
+                extends: extends.into_iter().filter(|e| e == "nothing").collect(),
+                structs,
+            })
+    );
 
     parser
         .parse(contents)

--- a/src/file_parsers/ao/parser.rs
+++ b/src/file_parsers/ao/parser.rs
@@ -8,8 +8,7 @@ use winnow::{
 
 use super::types::*;
 use crate::file_parsers::shared::winnow::{
-    WinnowParser, quoted_str, single_quoted_str, spaces_or_comments, unquoted_str,
-    version_line,
+    WinnowParser, quoted_str, single_quoted_str, spaces_or_comments, unquoted_str, version_line,
 };
 
 fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {

--- a/src/file_parsers/arm/parser.rs
+++ b/src/file_parsers/arm/parser.rs
@@ -40,24 +40,22 @@ fn F(input: &mut &str) -> winnow::Result<f32> {
 fn length_prefixed<'a, T>(
     item_parser: impl WinnowParser<&'a str, T>,
 ) -> impl SliceParser<'a, &'a str, Vec<T>> {
-    length_repeat(
+    winnow::trace!("length_prefixed", length_repeat(
         lift(U), //
         lift(item_parser),
-    )
-    .trace("length_prefixed")
+    ))
 }
 
 fn terminated<'a, T>(
     item_parser: impl WinnowParser<&'a str, T>,
     sentinel: &str,
 ) -> impl SliceParser<'a, &'a str, Vec<T>> {
-    repeat_till(
+    winnow::trace!("terminated", repeat_till(
         0.., //
         lift(item_parser),
         lift(literal(sentinel)),
     )
-    .map(|(items, _)| items)
-    .trace("terminated")
+    .map(|(items, _)| items))
 }
 
 /// Either length-prefixed or "-1"-terminated depending on version
@@ -65,32 +63,29 @@ fn group<'a, const V: u32, T>(
     version: u32,
     mut item_parser: impl WinnowParser<&'a str, T>,
 ) -> impl SliceParser<'a, &'a str, Vec<T>> {
-    dispatch! {
+    winnow::trace!("group", dispatch! {
         empty.value(version);
         v if v < V => length_prefixed(item_parser.by_ref()),
         v if v >= V => terminated(item_parser.by_ref(), "-1"),
         _ => fail,
-    }
-    .trace("group")
+    })
 }
 
 fn string_section<'a>() -> impl SliceParser<'a, &'a str, Vec<String>> {
-    length_repeat(
+    winnow::trace!("string_section", length_repeat(
         lift(U), //
         lift(quoted_str),
-    )
-    .trace("string_section")
+    ))
 }
 
 fn dimensions<'a>(version: u32) -> impl WinnowParser<&'a str, Dimension> {
-    (U, cond(version < 31, P(S, U)), cond(version >= 22, P(S, U)))
-        .map(|(side_length, _duplicate_side_length, uint1)| Dimension { side_length, uint1 })
-        .trace("dimensions")
+    winnow::trace!("dimensions", (U, cond(version < 31, P(S, U)), cond(version >= 22, P(S, U)))
+        .map(|(side_length, _duplicate_side_length, uint1)| Dimension { side_length, uint1 }))
 }
 
 /// "k" followed by 23-24 numbers
 fn slot_k<'a>(strings: &[String]) -> impl WinnowParser<&'a str, SlotK> {
-    (
+    winnow::trace!("slot_k", (
         separated_array(S, U),
         P(S, separated_array(S, U)),
         P(S, separated_array(S, U)),
@@ -125,7 +120,7 @@ fn slot_k<'a>(strings: &[String]) -> impl WinnowParser<&'a str, SlotK> {
                 .collect::<Vec<_>>()
                 .try_into()
                 .expect("Parser should take care of counts");
-
+    
                 let corners = izip!(
                     Direction::diagonals().into_iter(),
                     corner_grounds,
@@ -139,7 +134,7 @@ fn slot_k<'a>(strings: &[String]) -> impl WinnowParser<&'a str, SlotK> {
                 .collect::<Vec<_>>()
                 .try_into()
                 .expect("Parser should take care of counts");
-
+    
                 SlotK {
                     width: grid_dims[0],
                     height: grid_dims[1],
@@ -149,13 +144,12 @@ fn slot_k<'a>(strings: &[String]) -> impl WinnowParser<&'a str, SlotK> {
                     origin: Direction::diagonals()[origin_dir.unwrap_or(0) as usize],
                 }
             },
-        )
-        .trace("slot_k")
+        ))
 }
 
 /// k, f, s, o, n slots
 fn slot<'a>(strings: &[String]) -> impl WinnowParser<&'a str, Slot> {
-    dispatch! {
+    winnow::trace!("slot", dispatch! {
         any;
         'n' => empty.value(Slot::N),
         's' => empty.value(Slot::S),
@@ -165,8 +159,7 @@ fn slot<'a>(strings: &[String]) -> impl WinnowParser<&'a str, Slot> {
         }),
         'k' => P(S, slot_k(strings)).map(Slot::K),
         _ => fail,
-    }
-    .trace("slot")
+    })
 }
 
 /// Grid of Slots
@@ -175,19 +168,18 @@ fn grid<'a>(
     width: usize,
     strings: &'a [String],
 ) -> impl SliceParser<'a, &'a str, Vec<Vec<Slot>>> {
-    repeat(
+    winnow::trace!("grid", repeat(
         height, //
         lift::<_, _, Vec<_>, _>(
             separated(width, slot(strings), S), //
         )
         .trace("grid_row"),
-    )
-    .trace("grid")
+    ))
 }
 
 /// Single PoI line - 3 uints & a string
 fn poi<'a>() -> impl WinnowParser<&'a str, PoI> {
-    (
+    winnow::trace!("poi", (
         U,
         P(S, U),
         P(S, F),
@@ -199,8 +191,7 @@ fn poi<'a>() -> impl WinnowParser<&'a str, PoI> {
             y,
             rotation,
             tag,
-        })
-        .trace("poi")
+        }))
 }
 
 fn poi_groups<'a>(version: u32) -> impl SliceParser<'a, &'a str, Vec<Vec<PoI>>> {
@@ -212,22 +203,21 @@ fn poi_groups<'a>(version: u32) -> impl SliceParser<'a, &'a str, Vec<Vec<PoI>>> 
         29.. => 6,
     };
 
-    repeat(group_count, group::<32, _>(version, poi())).trace("poI_groups")
+    winnow::trace!("poI_groups", repeat(group_count, group::<32, _>(version, poi())))
 }
 
 /// key=value
 fn key_value<'a>() -> impl WinnowParser<&'a str, (&'a str, &'a str)> {
-    separated_pair(
+    winnow::trace!("key_value", separated_pair(
         take_while(1.., |c| c != '='),
         '=',
         take_while(1.., |c| c != ' '),
-    )
-    .trace("key_value")
+    ))
 }
 
 /// Single doodad string
 fn doodad<'a>(version: u32) -> impl WinnowParser<&'a str, Doodad> {
-    (
+    winnow::trace!("doodad", (
         U,
         P(S, U),
         cond(
@@ -276,14 +266,14 @@ fn doodad<'a>(version: u32) -> impl WinnowParser<&'a str, Doodad> {
                 } else {
                     [None; _]
                 };
-
+    
                 let key_values = key_values.map(|key_values: Vec<_>| {
                     key_values
                         .into_iter()
                         .map(|(k, v)| (k.to_string(), v.to_string()))
                         .collect()
                 });
-
+    
                 Doodad {
                     x,
                     y,
@@ -302,8 +292,7 @@ fn doodad<'a>(version: u32) -> impl WinnowParser<&'a str, Doodad> {
                     key_values,
                 }
             },
-        )
-        .trace("doodad")
+        ))
 }
 
 fn doodad_connections<'a>(version: u32) -> impl SliceParser<'a, &'a str, Vec<DoodadConnection>> {
@@ -314,12 +303,12 @@ fn doodad_connections<'a>(version: u32) -> impl SliceParser<'a, &'a str, Vec<Doo
     )
         .map(|(from, to, tag)| DoodadConnection { from, to, tag });
 
-    group::<32, _>(version, line_parser).trace("doodad_connections")
+    winnow::trace!("doodad_connections", group::<32, _>(version, line_parser))
 }
 
 /// Decal on a line
 fn decal<'a>(version: u32) -> impl WinnowParser<&'a str, Decal> {
-    (
+    winnow::trace!("decal", (
         separated_array::<3, _, _, _, _, _>(S, F),
         cond(version >= 17, P(S, parse_bool)),
         P(S, F),
@@ -334,8 +323,7 @@ fn decal<'a>(version: u32) -> impl WinnowParser<&'a str, Decal> {
             scale,
             atlas_file,
             tag,
-        })
-        .trace("decal")
+        }))
 }
 
 fn boss_lines<'a>() -> impl SliceParser<'a, &'a str, Vec<Vec<String>>> {
@@ -380,11 +368,11 @@ fn boss_lines<'a>() -> impl SliceParser<'a, &'a str, Vec<Vec<String>>> {
         Ok(boss_lines)
     };
 
-    parser.trace("boss_lines")
+    winnow::trace!("boss_lines", parser)
 }
 
 fn zone<'a>(version: u32) -> impl WinnowParser<&'a str, Zone> {
-    (
+    winnow::trace!("zone", (
         dispatch! {
             empty.value(version);
             ..35 => unquoted_str,
@@ -406,7 +394,7 @@ fn zone<'a>(version: u32) -> impl WinnowParser<&'a str, Zone> {
             } else {
                 (None, None, None)
             };
-
+    
             Zone {
                 name,
                 x_min,
@@ -417,16 +405,14 @@ fn zone<'a>(version: u32) -> impl WinnowParser<&'a str, Zone> {
                 env_file,
                 uint1,
             }
-        })
-        .trace("zone")
+        }))
 }
 
 fn tags<'a>() -> impl WinnowParser<&'a str, Vec<String>> {
-    length_repeat(
+    winnow::trace!("tags", length_repeat(
         U, //
         P(S, unquoted_str),
-    )
-    .trace("tags")
+    ))
 }
 
 /// Line of space separated uints, sometimes with a space a the end
@@ -435,7 +421,7 @@ fn ground_overrides<'a>(
     grid_height: usize,
     grid_width: usize,
 ) -> impl WinnowParser<&'a str, Vec<Vec<Option<String>>>> {
-    T(
+    winnow::trace!("ground_overrides", T(
         separated((grid_height - 1) * (grid_width - 1), U, S),
         space0,
     )
@@ -450,12 +436,11 @@ fn ground_overrides<'a>(
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>()
-    })
-    .trace("ground_overrides")
+    }))
 }
 
 fn thingy<'a>(strings: &[String]) -> impl WinnowParser<&'a str, Thingy> {
-    (
+    winnow::trace!("thingy", (
         U, //
         P(S, I),
         opt(P(S, parse_bool)),
@@ -464,7 +449,7 @@ fn thingy<'a>(strings: &[String]) -> impl WinnowParser<&'a str, Thingy> {
     )
         .map(|(i, int, bool1, bool2, bool3)| {
             let et_file = (i > 0).then(|| strings[i as usize - 1].clone());
-
+    
             Thingy {
                 et_file,
                 int,
@@ -472,8 +457,7 @@ fn thingy<'a>(strings: &[String]) -> impl WinnowParser<&'a str, Thingy> {
                 bool2,
                 bool3,
             }
-        })
-        .trace("thingy")
+        }))
 }
 
 pub fn parse_arm_str(input: &str) -> Result<ARMFile> {

--- a/src/file_parsers/arm/parser.rs
+++ b/src/file_parsers/arm/parser.rs
@@ -14,10 +14,7 @@ use winnow::{
 use super::types::*;
 use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
-    winnow::{
-        TraceHelper, WinnowParser, parse_bool, quoted_str, separated_array, unquoted_str,
-        version_line,
-    },
+    winnow::{WinnowParser, parse_bool, quoted_str, separated_array, unquoted_str, version_line},
 };
 
 // ==================================
@@ -40,22 +37,28 @@ fn F(input: &mut &str) -> winnow::Result<f32> {
 fn length_prefixed<'a, T>(
     item_parser: impl WinnowParser<&'a str, T>,
 ) -> impl SliceParser<'a, &'a str, Vec<T>> {
-    winnow::trace!("length_prefixed", length_repeat(
-        lift(U), //
-        lift(item_parser),
-    ))
+    winnow::trace!(
+        "length_prefixed",
+        length_repeat(
+            lift(U), //
+            lift(item_parser),
+        )
+    )
 }
 
 fn terminated<'a, T>(
     item_parser: impl WinnowParser<&'a str, T>,
     sentinel: &str,
 ) -> impl SliceParser<'a, &'a str, Vec<T>> {
-    winnow::trace!("terminated", repeat_till(
-        0.., //
-        lift(item_parser),
-        lift(literal(sentinel)),
+    winnow::trace!(
+        "terminated",
+        repeat_till(
+            0.., //
+            lift(item_parser),
+            lift(literal(sentinel)),
+        )
+        .map(|(items, _)| items)
     )
-    .map(|(items, _)| items))
 }
 
 /// Either length-prefixed or "-1"-terminated depending on version
@@ -63,103 +66,118 @@ fn group<'a, const V: u32, T>(
     version: u32,
     mut item_parser: impl WinnowParser<&'a str, T>,
 ) -> impl SliceParser<'a, &'a str, Vec<T>> {
-    winnow::trace!("group", dispatch! {
-        empty.value(version);
-        v if v < V => length_prefixed(item_parser.by_ref()),
-        v if v >= V => terminated(item_parser.by_ref(), "-1"),
-        _ => fail,
-    })
+    winnow::trace!(
+        "group",
+        dispatch! {
+            empty.value(version);
+            v if v < V => length_prefixed(item_parser.by_ref()),
+            v if v >= V => terminated(item_parser.by_ref(), "-1"),
+            _ => fail,
+        }
+    )
 }
 
 fn string_section<'a>() -> impl SliceParser<'a, &'a str, Vec<String>> {
-    winnow::trace!("string_section", length_repeat(
-        lift(U), //
-        lift(quoted_str),
-    ))
+    winnow::trace!(
+        "string_section",
+        length_repeat(
+            lift(U), //
+            lift(quoted_str),
+        )
+    )
 }
 
 fn dimensions<'a>(version: u32) -> impl WinnowParser<&'a str, Dimension> {
-    winnow::trace!("dimensions", (U, cond(version < 31, P(S, U)), cond(version >= 22, P(S, U)))
-        .map(|(side_length, _duplicate_side_length, uint1)| Dimension { side_length, uint1 }))
+    winnow::trace!(
+        "dimensions",
+        (U, cond(version < 31, P(S, U)), cond(version >= 22, P(S, U)))
+            .map(|(side_length, _duplicate_side_length, uint1)| Dimension { side_length, uint1 })
+    )
 }
 
 /// "k" followed by 23-24 numbers
 fn slot_k<'a>(strings: &[String]) -> impl WinnowParser<&'a str, SlotK> {
-    winnow::trace!("slot_k", (
-        separated_array(S, U),
-        P(S, separated_array(S, U)),
-        P(S, separated_array(S, U)),
-        P(S, separated_array(S, U)),
-        P(S, separated_array(S, I)),
-        P(S, U),
-        opt(P(' ', U)),
-    )
-        .map(
-            |(
-                grid_dims, //
-                edges,
-                exits,
-                corner_grounds,
-                corner_heights,
-                slot_tag,
-                origin_dir,
-            ): ([_; 2], [_; 4], [_; 8], [_; 4], [_; 4], _, _)| {
-                let edges = izip!(
-                    Direction::cardinal().into_iter(),
+    winnow::trace!(
+        "slot_k",
+        (
+            separated_array(S, U),
+            P(S, separated_array(S, U)),
+            P(S, separated_array(S, U)),
+            P(S, separated_array(S, U)),
+            P(S, separated_array(S, I)),
+            P(S, U),
+            opt(P(' ', U)),
+        )
+            .map(
+                |(
+                    grid_dims, //
                     edges,
-                    exits.into_iter().tuples(),
-                )
-                .map(|(direction, edge, (exit, virtual_exit))| Edge {
-                    direction,
-                    // 0 -> None,
-                    // i -> Some(i - 1)
-                    edge: (edge > 0).then(|| strings[(edge - 1) as usize].clone()),
-                    exit,
-                    virtual_exit,
-                })
-                .collect::<Vec<_>>()
-                .try_into()
-                .expect("Parser should take care of counts");
-    
-                let corners = izip!(
-                    Direction::diagonals().into_iter(),
+                    exits,
                     corner_grounds,
                     corner_heights,
-                )
-                .map(|(direction, ground, height)| Corner {
-                    direction,
-                    ground: (ground > 0).then(|| strings[ground as usize - 1].clone()),
-                    height,
-                })
-                .collect::<Vec<_>>()
-                .try_into()
-                .expect("Parser should take care of counts");
-    
-                SlotK {
-                    width: grid_dims[0],
-                    height: grid_dims[1],
-                    edges,
-                    corners,
-                    slot_tag: (slot_tag > 0).then(|| strings[slot_tag as usize - 1].clone()),
-                    origin: Direction::diagonals()[origin_dir.unwrap_or(0) as usize],
-                }
-            },
-        ))
+                    slot_tag,
+                    origin_dir,
+                ): ([_; 2], [_; 4], [_; 8], [_; 4], [_; 4], _, _)| {
+                    let edges = izip!(
+                        Direction::cardinal().into_iter(),
+                        edges,
+                        exits.into_iter().tuples(),
+                    )
+                    .map(|(direction, edge, (exit, virtual_exit))| Edge {
+                        direction,
+                        // 0 -> None,
+                        // i -> Some(i - 1)
+                        edge: (edge > 0).then(|| strings[(edge - 1) as usize].clone()),
+                        exit,
+                        virtual_exit,
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .expect("Parser should take care of counts");
+
+                    let corners = izip!(
+                        Direction::diagonals().into_iter(),
+                        corner_grounds,
+                        corner_heights,
+                    )
+                    .map(|(direction, ground, height)| Corner {
+                        direction,
+                        ground: (ground > 0).then(|| strings[ground as usize - 1].clone()),
+                        height,
+                    })
+                    .collect::<Vec<_>>()
+                    .try_into()
+                    .expect("Parser should take care of counts");
+
+                    SlotK {
+                        width: grid_dims[0],
+                        height: grid_dims[1],
+                        edges,
+                        corners,
+                        slot_tag: (slot_tag > 0).then(|| strings[slot_tag as usize - 1].clone()),
+                        origin: Direction::diagonals()[origin_dir.unwrap_or(0) as usize],
+                    }
+                },
+            )
+    )
 }
 
 /// k, f, s, o, n slots
 fn slot<'a>(strings: &[String]) -> impl WinnowParser<&'a str, Slot> {
-    winnow::trace!("slot", dispatch! {
-        any;
-        'n' => empty.value(Slot::N),
-        's' => empty.value(Slot::S),
-        'o' => empty.value(Slot::O),
-        'f' => P(S, U).map(|i | Slot::F {
-            fill: (i > 0).then(|| strings[i as usize - 1].clone()),
-        }),
-        'k' => P(S, slot_k(strings)).map(Slot::K),
-        _ => fail,
-    })
+    winnow::trace!(
+        "slot",
+        dispatch! {
+            any;
+            'n' => empty.value(Slot::N),
+            's' => empty.value(Slot::S),
+            'o' => empty.value(Slot::O),
+            'f' => P(S, U).map(|i | Slot::F {
+                fill: (i > 0).then(|| strings[i as usize - 1].clone()),
+            }),
+            'k' => P(S, slot_k(strings)).map(Slot::K),
+            _ => fail,
+        }
+    )
 }
 
 /// Grid of Slots
@@ -168,30 +186,38 @@ fn grid<'a>(
     width: usize,
     strings: &'a [String],
 ) -> impl SliceParser<'a, &'a str, Vec<Vec<Slot>>> {
-    winnow::trace!("grid", repeat(
-        height, //
-        lift::<_, _, Vec<_>, _>(
-            separated(width, slot(strings), S), //
+    winnow::trace!(
+        "grid",
+        repeat(
+            height, //
+            winnow::trace!(
+                "grid_row",
+                lift::<_, _, Vec<_>, _>(
+                    separated(width, slot(strings), S), //
+                )
+            ),
         )
-        .trace("grid_row"),
-    ))
+    )
 }
 
 /// Single PoI line - 3 uints & a string
 fn poi<'a>() -> impl WinnowParser<&'a str, PoI> {
-    winnow::trace!("poi", (
-        U,
-        P(S, U),
-        P(S, F),
-        // TODO: Remove \u0000 chars from this
-        P(S, quoted_str),
+    winnow::trace!(
+        "poi",
+        (
+            U,
+            P(S, U),
+            P(S, F),
+            // TODO: Remove \u0000 chars from this
+            P(S, quoted_str),
+        )
+            .map(|(x, y, rotation, tag)| PoI {
+                x,
+                y,
+                rotation,
+                tag,
+            })
     )
-        .map(|(x, y, rotation, tag)| PoI {
-            x,
-            y,
-            rotation,
-            tag,
-        }))
 }
 
 fn poi_groups<'a>(version: u32) -> impl SliceParser<'a, &'a str, Vec<Vec<PoI>>> {
@@ -203,86 +229,64 @@ fn poi_groups<'a>(version: u32) -> impl SliceParser<'a, &'a str, Vec<Vec<PoI>>> 
         29.. => 6,
     };
 
-    winnow::trace!("poI_groups", repeat(group_count, group::<32, _>(version, poi())))
+    winnow::trace!(
+        "poI_groups",
+        repeat(group_count, group::<32, _>(version, poi()))
+    )
 }
 
 /// key=value
 fn key_value<'a>() -> impl WinnowParser<&'a str, (&'a str, &'a str)> {
-    winnow::trace!("key_value", separated_pair(
-        take_while(1.., |c| c != '='),
-        '=',
-        take_while(1.., |c| c != ' '),
-    ))
+    winnow::trace!(
+        "key_value",
+        separated_pair(
+            take_while(1.., |c| c != '='),
+            '=',
+            take_while(1.., |c| c != ' '),
+        )
+    )
 }
 
 /// Single doodad string
 fn doodad<'a>(version: u32) -> impl WinnowParser<&'a str, Doodad> {
-    winnow::trace!("doodad", (
-        U,
-        P(S, U),
-        cond(
-            version >= 34,
-            P(
-                S,
-                length_repeat(
-                    U, //
-                    (P(S, F), P(S, F)),
+    winnow::trace!(
+        "doodad",
+        (
+            U,
+            P(S, U),
+            cond(
+                version >= 34,
+                P(
+                    S,
+                    length_repeat(
+                        U, //
+                        (P(S, F), P(S, F)),
+                    ),
                 ),
             ),
-        ),
-        P(S, F),
-        cond(
-            version >= 18, //
-            P(S, separated_array(S, F)),
-        ),
-        P(S, parse_bool),
-        cond(
-            version >= 25, //
+            P(S, F),
+            cond(
+                version >= 18, //
+                P(S, separated_array(S, F)),
+            ),
             P(S, parse_bool),
-        ),
-        P(S, length_repeat(U, P(S, F))),
-        P(S, F),
-        P(S, quoted_str),
-        P(S, quoted_str),
-        cond(version >= 36, P(S, length_repeat(U, P(S, key_value())))),
-    )
-        .map(
-            |(
-                x,
-                y,
-                float_pairs,
-                radians1,
-                trigs,
-                bool1,
-                bool2,
-                floats,
-                scale,
-                ao_file,
-                stub,
-                key_values,
-            )| {
-                let [trig1, trig2, trig3, trig4] = if let Some(trigs) = trigs {
-                    trigs.map(Some)
-                } else {
-                    [None; _]
-                };
-    
-                let key_values = key_values.map(|key_values: Vec<_>| {
-                    key_values
-                        .into_iter()
-                        .map(|(k, v)| (k.to_string(), v.to_string()))
-                        .collect()
-                });
-    
-                Doodad {
+            cond(
+                version >= 25, //
+                P(S, parse_bool),
+            ),
+            P(S, length_repeat(U, P(S, F))),
+            P(S, F),
+            P(S, quoted_str),
+            P(S, quoted_str),
+            cond(version >= 36, P(S, length_repeat(U, P(S, key_value())))),
+        )
+            .map(
+                |(
                     x,
                     y,
                     float_pairs,
                     radians1,
-                    trig1,
-                    trig2,
-                    trig3,
-                    trig4,
+                    trigs,
                     bool1,
                     bool2,
                     floats,
@@ -290,9 +294,40 @@ fn doodad<'a>(version: u32) -> impl WinnowParser<&'a str, Doodad> {
                     ao_file,
                     stub,
                     key_values,
-                }
-            },
-        ))
+                )| {
+                    let [trig1, trig2, trig3, trig4] = if let Some(trigs) = trigs {
+                        trigs.map(Some)
+                    } else {
+                        [None; _]
+                    };
+
+                    let key_values = key_values.map(|key_values: Vec<_>| {
+                        key_values
+                            .into_iter()
+                            .map(|(k, v)| (k.to_string(), v.to_string()))
+                            .collect()
+                    });
+
+                    Doodad {
+                        x,
+                        y,
+                        float_pairs,
+                        radians1,
+                        trig1,
+                        trig2,
+                        trig3,
+                        trig4,
+                        bool1,
+                        bool2,
+                        floats,
+                        scale,
+                        ao_file,
+                        stub,
+                        key_values,
+                    }
+                },
+            )
+    )
 }
 
 fn doodad_connections<'a>(version: u32) -> impl SliceParser<'a, &'a str, Vec<DoodadConnection>> {
@@ -308,22 +343,25 @@ fn doodad_connections<'a>(version: u32) -> impl SliceParser<'a, &'a str, Vec<Doo
 
 /// Decal on a line
 fn decal<'a>(version: u32) -> impl WinnowParser<&'a str, Decal> {
-    winnow::trace!("decal", (
-        separated_array::<3, _, _, _, _, _>(S, F),
-        cond(version >= 17, P(S, parse_bool)),
-        P(S, F),
-        P(S, quoted_str),
-        P(S, quoted_str),
+    winnow::trace!(
+        "decal",
+        (
+            separated_array::<3, _, _, _, _, _>(S, F),
+            cond(version >= 17, P(S, parse_bool)),
+            P(S, F),
+            P(S, quoted_str),
+            P(S, quoted_str),
+        )
+            .map(|([x, y, rotation], bool1, scale, atlas_file, tag)| Decal {
+                x,
+                y,
+                rotation,
+                bool1,
+                scale,
+                atlas_file,
+                tag,
+            })
     )
-        .map(|([x, y, rotation], bool1, scale, atlas_file, tag)| Decal {
-            x,
-            y,
-            rotation,
-            bool1,
-            scale,
-            atlas_file,
-            tag,
-        }))
 }
 
 fn boss_lines<'a>() -> impl SliceParser<'a, &'a str, Vec<Vec<String>>> {
@@ -372,47 +410,53 @@ fn boss_lines<'a>() -> impl SliceParser<'a, &'a str, Vec<Vec<String>>> {
 }
 
 fn zone<'a>(version: u32) -> impl WinnowParser<&'a str, Zone> {
-    winnow::trace!("zone", (
-        dispatch! {
-            empty.value(version);
-            ..35 => unquoted_str,
-            35.. => quoted_str,
-        },
-        P(S, separated_array::<4, _, _, _, _, _>(S, I)),
-        cond(
-            version >= 35,
-            (
-                P(S, quoted_str), //
-                P(S, quoted_str),
-                P(S, U),
+    winnow::trace!(
+        "zone",
+        (
+            dispatch! {
+                empty.value(version);
+                ..35 => unquoted_str,
+                35.. => quoted_str,
+            },
+            P(S, separated_array::<4, _, _, _, _, _>(S, I)),
+            cond(
+                version >= 35,
+                (
+                    P(S, quoted_str), //
+                    P(S, quoted_str),
+                    P(S, U),
+                ),
             ),
-        ),
+        )
+            .map(|(name, [x_min, y_min, x_max, y_max], optionals)| {
+                let (disable_teleports, env_file, uint1) = if let Some((d, e, u)) = optionals {
+                    (Some(d), Some(e), Some(u))
+                } else {
+                    (None, None, None)
+                };
+
+                Zone {
+                    name,
+                    x_min,
+                    y_min,
+                    x_max,
+                    y_max,
+                    disable_teleports,
+                    env_file,
+                    uint1,
+                }
+            })
     )
-        .map(|(name, [x_min, y_min, x_max, y_max], optionals)| {
-            let (disable_teleports, env_file, uint1) = if let Some((d, e, u)) = optionals {
-                (Some(d), Some(e), Some(u))
-            } else {
-                (None, None, None)
-            };
-    
-            Zone {
-                name,
-                x_min,
-                y_min,
-                x_max,
-                y_max,
-                disable_teleports,
-                env_file,
-                uint1,
-            }
-        }))
 }
 
 fn tags<'a>() -> impl WinnowParser<&'a str, Vec<String>> {
-    winnow::trace!("tags", length_repeat(
-        U, //
-        P(S, unquoted_str),
-    ))
+    winnow::trace!(
+        "tags",
+        length_repeat(
+            U, //
+            P(S, unquoted_str),
+        )
+    )
 }
 
 /// Line of space separated uints, sometimes with a space a the end
@@ -421,43 +465,49 @@ fn ground_overrides<'a>(
     grid_height: usize,
     grid_width: usize,
 ) -> impl WinnowParser<&'a str, Vec<Vec<Option<String>>>> {
-    winnow::trace!("ground_overrides", T(
-        separated((grid_height - 1) * (grid_width - 1), U, S),
-        space0,
+    winnow::trace!(
+        "ground_overrides",
+        T(
+            separated((grid_height - 1) * (grid_width - 1), U, S),
+            space0,
+        )
+        .map(move |indices: Vec<_>| {
+            // Chunk into 2D grid
+            indices
+                .into_iter()
+                .chunks(grid_width - 1)
+                .into_iter()
+                .map(|c| {
+                    c.map(|i| (i > 0).then(|| strings[i as usize - 1].clone()))
+                        .collect::<Vec<_>>()
+                })
+                .collect::<Vec<_>>()
+        })
     )
-    .map(move |indices: Vec<_>| {
-        // Chunk into 2D grid
-        indices
-            .into_iter()
-            .chunks(grid_width - 1)
-            .into_iter()
-            .map(|c| {
-                c.map(|i| (i > 0).then(|| strings[i as usize - 1].clone()))
-                    .collect::<Vec<_>>()
-            })
-            .collect::<Vec<_>>()
-    }))
 }
 
 fn thingy<'a>(strings: &[String]) -> impl WinnowParser<&'a str, Thingy> {
-    winnow::trace!("thingy", (
-        U, //
-        P(S, I),
-        opt(P(S, parse_bool)),
-        opt(P(S, parse_bool)),
-        opt(P(S, parse_bool)),
+    winnow::trace!(
+        "thingy",
+        (
+            U, //
+            P(S, I),
+            opt(P(S, parse_bool)),
+            opt(P(S, parse_bool)),
+            opt(P(S, parse_bool)),
+        )
+            .map(|(i, int, bool1, bool2, bool3)| {
+                let et_file = (i > 0).then(|| strings[i as usize - 1].clone());
+
+                Thingy {
+                    et_file,
+                    int,
+                    bool1,
+                    bool2,
+                    bool3,
+                }
+            })
     )
-        .map(|(i, int, bool1, bool2, bool3)| {
-            let et_file = (i > 0).then(|| strings[i as usize - 1].clone());
-    
-            Thingy {
-                et_file,
-                int,
-                bool1,
-                bool2,
-                bool3,
-            }
-        }))
 }
 
 pub fn parse_arm_str(input: &str) -> Result<ARMFile> {

--- a/src/file_parsers/bundle/parser.rs
+++ b/src/file_parsers/bundle/parser.rs
@@ -9,7 +9,7 @@ use winnow::{
 };
 
 use super::types::*;
-use crate::file_parsers::shared::winnow::{TraceHelper, WinnowParser};
+use crate::file_parsers::shared::winnow::WinnowParser;
 
 #[derive(Debug)]
 enum BundleError {
@@ -26,7 +26,7 @@ impl Display for BundleError {
 impl std::error::Error for BundleError {}
 
 fn first_file_encode<'a>() -> impl WinnowParser<&'a [u8], FirstFileEncode> {
-    le_u32
+    winnow::trace!("first_file_encode", le_u32
         .try_map(|x| {
             use FirstFileEncode::*;
             let ffe = match x {
@@ -38,14 +38,13 @@ fn first_file_encode<'a>() -> impl WinnowParser<&'a [u8], FirstFileEncode> {
                     return Err(BundleError::InvalidEncoding(x));
                 }
             };
-
+    
             Ok(ffe)
-        })
-        .trace("first_file_encode")
+        }))
 }
 
 fn head_payload<'a>() -> impl WinnowParser<&'a [u8], (HeadPayload, u32)> {
-    seq!((
+    winnow::trace!("head_payload", seq!((
         _: take(12_usize),
         first_file_encode(),
         _: take(4_usize),
@@ -69,11 +68,10 @@ fn head_payload<'a>() -> impl WinnowParser<&'a [u8], (HeadPayload, u32)> {
                 total_payload_size,
                 uncompressed_block_granularity,
             };
-
+    
             (head_payload, block_count)
         },
-    )
-    .trace("head_payload")
+    ))
 }
 
 fn blocks<'a>(block_count: u32) -> impl WinnowParser<&'a [u8], Vec<Vec<u8>>> {
@@ -89,7 +87,7 @@ fn blocks<'a>(block_count: u32) -> impl WinnowParser<&'a [u8], Vec<Vec<u8>>> {
         Ok(blocks)
     };
 
-    parser.trace("blocks")
+    winnow::trace!("blocks", parser)
 }
 
 pub fn bundle<'a>() -> impl WinnowParser<&'a [u8], BundleFile> {
@@ -103,7 +101,7 @@ pub fn bundle<'a>() -> impl WinnowParser<&'a [u8], BundleFile> {
         Ok(bundle)
     };
 
-    parser.trace("bundle")
+    winnow::trace!("bundle", parser)
 }
 
 pub fn parse_bundle_bytes(contents: &[u8]) -> Result<BundleFile> {

--- a/src/file_parsers/bundle/parser.rs
+++ b/src/file_parsers/bundle/parser.rs
@@ -26,8 +26,9 @@ impl Display for BundleError {
 impl std::error::Error for BundleError {}
 
 fn first_file_encode<'a>() -> impl WinnowParser<&'a [u8], FirstFileEncode> {
-    winnow::trace!("first_file_encode", le_u32
-        .try_map(|x| {
+    winnow::trace!(
+        "first_file_encode",
+        le_u32.try_map(|x| {
             use FirstFileEncode::*;
             let ffe = match x {
                 8 => Kraken6,
@@ -38,40 +39,44 @@ fn first_file_encode<'a>() -> impl WinnowParser<&'a [u8], FirstFileEncode> {
                     return Err(BundleError::InvalidEncoding(x));
                 }
             };
-    
+
             Ok(ffe)
-        }))
+        })
+    )
 }
 
 fn head_payload<'a>() -> impl WinnowParser<&'a [u8], (HeadPayload, u32)> {
-    winnow::trace!("head_payload", seq!((
-        _: take(12_usize),
-        first_file_encode(),
-        _: take(4_usize),
-        le_u64,
-        le_u64,
-        le_u32,
-        le_u32,
-        _: take(16_usize),
-    ))
-    .map(
-        |(
-            first_file_encode,
-            uncompressed_size,
-            total_payload_size,
-            block_count,
-            uncompressed_block_granularity,
-        )| {
-            let head_payload = HeadPayload {
+    winnow::trace!(
+        "head_payload",
+        seq!((
+            _: take(12_usize),
+            first_file_encode(),
+            _: take(4_usize),
+            le_u64,
+            le_u64,
+            le_u32,
+            le_u32,
+            _: take(16_usize),
+        ))
+        .map(
+            |(
                 first_file_encode,
                 uncompressed_size,
                 total_payload_size,
+                block_count,
                 uncompressed_block_granularity,
-            };
-    
-            (head_payload, block_count)
-        },
-    ))
+            )| {
+                let head_payload = HeadPayload {
+                    first_file_encode,
+                    uncompressed_size,
+                    total_payload_size,
+                    uncompressed_block_granularity,
+                };
+
+                (head_payload, block_count)
+            },
+        )
+    )
 }
 
 fn blocks<'a>(block_count: u32) -> impl WinnowParser<&'a [u8], Vec<Vec<u8>>> {

--- a/src/file_parsers/bundle_index/parser.rs
+++ b/src/file_parsers/bundle_index/parser.rs
@@ -7,41 +7,38 @@ use winnow::{
 use super::types::*;
 use crate::file_parsers::{
     bundle::parser::bundle,
-    shared::winnow::{TraceHelper, WinnowParser},
+    shared::winnow::WinnowParser,
 };
 
 fn bundle_info<'a>() -> impl WinnowParser<&'a [u8], BundleInfo> {
-    (
+    winnow::trace!("bundle_info", (
         length_take(le_u32).try_map(|bytes: &[_]| String::from_utf8(bytes.to_vec())),
         le_u32,
     )
         .map(|(name, uncompressed_size)| BundleInfo {
             name,
             uncompressed_size,
-        })
-        .trace("bundle_info")
+        }))
 }
 
 fn file_info<'a>() -> impl WinnowParser<&'a [u8], FileInfo> {
-    (le_u64, le_u32, le_u32, le_u32) //
+    winnow::trace!("file_info", (le_u64, le_u32, le_u32, le_u32) //
         .map(|(hash, bundle_index, offset, size)| FileInfo {
             hash,
             bundle_index,
             offset,
             size,
-        })
-        .trace("file_info")
+        }))
 }
 
 fn path_rep<'a>() -> impl WinnowParser<&'a [u8], PathRep> {
-    (le_u64, le_u32, le_u32, le_u32) //
+    winnow::trace!("path_rep", (le_u64, le_u32, le_u32, le_u32) //
         .map(|(hash, offset, size, recursive_size)| PathRep {
             hash,
             offset,
             size,
             recursive_size,
-        })
-        .trace("path_rep")
+        }))
 }
 
 pub fn parse_bundle_index_bytes(contents: &[u8]) -> Result<BundleIndexFile> {

--- a/src/file_parsers/bundle_index/parser.rs
+++ b/src/file_parsers/bundle_index/parser.rs
@@ -5,40 +5,46 @@ use winnow::{
 };
 
 use super::types::*;
-use crate::file_parsers::{
-    bundle::parser::bundle,
-    shared::winnow::WinnowParser,
-};
+use crate::file_parsers::{bundle::parser::bundle, shared::winnow::WinnowParser};
 
 fn bundle_info<'a>() -> impl WinnowParser<&'a [u8], BundleInfo> {
-    winnow::trace!("bundle_info", (
-        length_take(le_u32).try_map(|bytes: &[_]| String::from_utf8(bytes.to_vec())),
-        le_u32,
+    winnow::trace!(
+        "bundle_info",
+        (
+            length_take(le_u32).try_map(|bytes: &[_]| String::from_utf8(bytes.to_vec())),
+            le_u32,
+        )
+            .map(|(name, uncompressed_size)| BundleInfo {
+                name,
+                uncompressed_size,
+            })
     )
-        .map(|(name, uncompressed_size)| BundleInfo {
-            name,
-            uncompressed_size,
-        }))
 }
 
 fn file_info<'a>() -> impl WinnowParser<&'a [u8], FileInfo> {
-    winnow::trace!("file_info", (le_u64, le_u32, le_u32, le_u32) //
-        .map(|(hash, bundle_index, offset, size)| FileInfo {
-            hash,
-            bundle_index,
-            offset,
-            size,
-        }))
+    winnow::trace!(
+        "file_info",
+        (le_u64, le_u32, le_u32, le_u32) //
+            .map(|(hash, bundle_index, offset, size)| FileInfo {
+                hash,
+                bundle_index,
+                offset,
+                size,
+            })
+    )
 }
 
 fn path_rep<'a>() -> impl WinnowParser<&'a [u8], PathRep> {
-    winnow::trace!("path_rep", (le_u64, le_u32, le_u32, le_u32) //
-        .map(|(hash, offset, size, recursive_size)| PathRep {
-            hash,
-            offset,
-            size,
-            recursive_size,
-        }))
+    winnow::trace!(
+        "path_rep",
+        (le_u64, le_u32, le_u32, le_u32) //
+            .map(|(hash, offset, size, recursive_size)| PathRep {
+                hash,
+                offset,
+                size,
+                recursive_size,
+            })
+    )
 }
 
 pub fn parse_bundle_index_bytes(contents: &[u8]) -> Result<BundleIndexFile> {

--- a/src/file_parsers/cht/parser.rs
+++ b/src/file_parsers/cht/parser.rs
@@ -8,11 +8,11 @@ use winnow::{
 use super::types::*;
 use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
-    winnow::{TraceHelper, WinnowParser, quoted_comma_separated, version_line},
+    winnow::{WinnowParser, quoted_comma_separated, version_line},
 };
 
 fn num_line<'a>(version: u32) -> impl WinnowParser<&'a str, Nums> {
-    (
+    winnow::trace!("num_line", (
         float, //
         P(space1, float),
         P(space1, dec_uint),
@@ -25,20 +25,18 @@ fn num_line<'a>(version: u32) -> impl WinnowParser<&'a str, Nums> {
             uint1,
             uint2,
             uint3,
-        })
-        .trace("num_line")
+        }))
 }
 
 fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
-    (
+    winnow::trace!("entry", (
         dec_uint, //
         P(space1, quoted_comma_separated()),
     )
         .map(|(weight, chest_types)| Entry {
             weight,
             chest_types,
-        })
-        .trace("entry")
+        }))
 }
 
 fn group<'a, const NAMED: bool>(version: u32) -> impl SliceParser<'a, &'a str, Group> {
@@ -57,7 +55,7 @@ fn group<'a, const NAMED: bool>(version: u32) -> impl SliceParser<'a, &'a str, G
                 ),
     };
 
-    (
+    winnow::trace!("group", (
         lift(header), //
         repeat(0.., lift(entry())),
     )
@@ -65,8 +63,7 @@ fn group<'a, const NAMED: bool>(version: u32) -> impl SliceParser<'a, &'a str, G
             areas,
             entries,
             nums,
-        })
-        .trace("group")
+        }))
 }
 
 pub fn parse_cht_str(contents: &str) -> Result<CHTFile> {
@@ -82,7 +79,7 @@ pub fn parse_cht_str(contents: &str) -> Result<CHTFile> {
         .map_err(|e| anyhow!("Failed to parse file: {e:?}"))?;
 
     let mut parser = (
-        group::<false>(version).trace("default_group"),
+        winnow::trace!("default_group", group::<false>(version)),
         repeat(0.., group::<true>(version)),
     )
         .map(|(default_group, mut groups)| {

--- a/src/file_parsers/cht/parser.rs
+++ b/src/file_parsers/cht/parser.rs
@@ -12,31 +12,37 @@ use crate::file_parsers::shared::{
 };
 
 fn num_line<'a>(version: u32) -> impl WinnowParser<&'a str, Nums> {
-    winnow::trace!("num_line", (
-        float, //
-        P(space1, float),
-        P(space1, dec_uint),
-        P(space1, dec_uint),
-        cond(version >= 3, P(space1, dec_uint)),
+    winnow::trace!(
+        "num_line",
+        (
+            float, //
+            P(space1, float),
+            P(space1, dec_uint),
+            P(space1, dec_uint),
+            cond(version >= 3, P(space1, dec_uint)),
+        )
+            .map(|(float1, float2, uint1, uint2, uint3)| Nums {
+                float1,
+                float2,
+                uint1,
+                uint2,
+                uint3,
+            })
     )
-        .map(|(float1, float2, uint1, uint2, uint3)| Nums {
-            float1,
-            float2,
-            uint1,
-            uint2,
-            uint3,
-        }))
 }
 
 fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
-    winnow::trace!("entry", (
-        dec_uint, //
-        P(space1, quoted_comma_separated()),
+    winnow::trace!(
+        "entry",
+        (
+            dec_uint, //
+            P(space1, quoted_comma_separated()),
+        )
+            .map(|(weight, chest_types)| Entry {
+                weight,
+                chest_types,
+            })
     )
-        .map(|(weight, chest_types)| Entry {
-            weight,
-            chest_types,
-        }))
 }
 
 fn group<'a, const NAMED: bool>(version: u32) -> impl SliceParser<'a, &'a str, Group> {
@@ -55,15 +61,18 @@ fn group<'a, const NAMED: bool>(version: u32) -> impl SliceParser<'a, &'a str, G
                 ),
     };
 
-    winnow::trace!("group", (
-        lift(header), //
-        repeat(0.., lift(entry())),
+    winnow::trace!(
+        "group",
+        (
+            lift(header), //
+            repeat(0.., lift(entry())),
+        )
+            .map(|((areas, nums), entries)| Group {
+                areas,
+                entries,
+                nums,
+            })
     )
-        .map(|((areas, nums), entries)| Group {
-            areas,
-            entries,
-            nums,
-        }))
 }
 
 pub fn parse_cht_str(contents: &str) -> Result<CHTFile> {

--- a/src/file_parsers/clt/parser.rs
+++ b/src/file_parsers/clt/parser.rs
@@ -8,49 +8,53 @@ use winnow::{
 use super::types::*;
 use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
-    winnow::{TraceHelper, WinnowParser, filename, quoted, quoted_str, unquoted_str, version_line},
+    winnow::{WinnowParser, filename, quoted, quoted_str, unquoted_str, version_line},
 };
 
 pub fn item<'a>(version: u32) -> impl WinnowParser<&'a str, Item> {
-    (
-        dec_uint,
-        P(space1, quoted_str),
-        cond(
-            version >= 4,
-            P(space1, quoted('"').and_then(filename("ao"))),
-        ),
-        P(space1, float),
-        cond(
-            version >= 3, //
+    winnow::trace!(
+        "item",
+        (
+            dec_uint,
+            P(space1, quoted_str),
+            cond(
+                version >= 4,
+                P(space1, quoted('"').and_then(filename("ao"))),
+            ),
             P(space1, float),
-        ),
-        P(space1, dec_uint),
-        P(space1, dec_uint),
-    )
-        .map(
-            |(uint1, stub, ao_file, float1, float2, uint2, uint3)| Item {
-                uint1,
-                stub,
-                ao_file,
-                float1,
-                float2,
-                uint2,
-                uint3,
-            },
+            cond(
+                version >= 3, //
+                P(space1, float),
+            ),
+            P(space1, dec_uint),
+            P(space1, dec_uint),
         )
-        .trace("item")
+            .map(
+                |(uint1, stub, ao_file, float1, float2, uint2, uint3)| Item {
+                    uint1,
+                    stub,
+                    ao_file,
+                    float1,
+                    float2,
+                    uint2,
+                    uint3,
+                },
+            )
+    )
 }
 
 pub fn group<'a>(version: u32) -> impl SliceParser<'a, &'a str, Group> {
-    (
-        lift((
-            alt((quoted_str, unquoted_str)), //
-            opt(P(space1, float)),
-        )),
-        repeat(0.., lift(item(version))),
+    winnow::trace!(
+        "group",
+        (
+            lift((
+                alt((quoted_str, unquoted_str)), //
+                opt(P(space1, float)),
+            )),
+            repeat(0.., lift(item(version))),
+        )
+            .map(|((name, float), items)| Group { name, float, items })
     )
-        .map(|((name, float), items)| Group { name, float, items })
-        .trace("group")
 }
 
 pub fn parse_clt_str(contents: &str) -> Result<CLTFile> {

--- a/src/file_parsers/dat/parser.rs
+++ b/src/file_parsers/dat/parser.rs
@@ -11,7 +11,7 @@ use crate::file_parsers::shared::winnow::WinnowParser;
 
 fn table_section<'a>() -> impl WinnowParser<&'a [u8], &'a [u8]> {
     terminated(
-        take_until(1.., [0xBB; 8].as_slice()), //
+        take_until(0.., [0xBB; 8].as_slice()), //
         [0xBB; 8].as_slice(),
     )
 }

--- a/src/file_parsers/dct/parser.rs
+++ b/src/file_parsers/dct/parser.rs
@@ -9,11 +9,11 @@ use winnow::{
 use super::types::*;
 use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
-    winnow::{TraceHelper, WinnowParser, filename, quoted, quoted_str, version_line},
+    winnow::{WinnowParser, filename, quoted, quoted_str, version_line},
 };
 
 fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
-    (
+    winnow::trace!("entry", (
         dec_uint, //
         P(space1, quoted('"').and_then(filename("atlas"))),
         P(space1, quoted_str),
@@ -26,8 +26,7 @@ fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
             tag,
             float1,
             float2,
-        })
-        .trace("entry")
+        }))
 }
 
 fn header<'a>() -> impl WinnowParser<&'a str, (String, Option<f32>)> {
@@ -38,7 +37,7 @@ fn header<'a>() -> impl WinnowParser<&'a str, (String, Option<f32>)> {
 }
 
 fn group<'a>() -> impl SliceParser<'a, &'a str, Group> {
-    (
+    winnow::trace!("group", (
         lift(header()), //
         repeat(0.., lift(entry())),
     )
@@ -46,12 +45,11 @@ fn group<'a>() -> impl SliceParser<'a, &'a str, Group> {
             area,
             float,
             entries,
-        })
-        .trace("group")
+        }))
 }
 
 fn default_group<'a>() -> impl SliceParser<'a, &'a str, Group> {
-    (
+    winnow::trace!("default_group", (
         lift(literal("Default").map(String::from)), //
         repeat(0.., lift(entry())),
     )
@@ -59,8 +57,7 @@ fn default_group<'a>() -> impl SliceParser<'a, &'a str, Group> {
             area,
             float: None,
             entries,
-        })
-        .trace("default_group")
+        }))
 }
 
 pub fn parse_dct_str(contents: &str) -> Result<DCTFile> {

--- a/src/file_parsers/dct/parser.rs
+++ b/src/file_parsers/dct/parser.rs
@@ -13,20 +13,23 @@ use crate::file_parsers::shared::{
 };
 
 fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
-    winnow::trace!("entry", (
-        dec_uint, //
-        P(space1, quoted('"').and_then(filename("atlas"))),
-        P(space1, quoted_str),
-        P(space1, float),
-        opt(P(space1, float)),
+    winnow::trace!(
+        "entry",
+        (
+            dec_uint, //
+            P(space1, quoted('"').and_then(filename("atlas"))),
+            P(space1, quoted_str),
+            P(space1, float),
+            opt(P(space1, float)),
+        )
+            .map(|(weight, atlas_file, tag, float1, float2)| Entry {
+                weight,
+                atlas_file,
+                tag,
+                float1,
+                float2,
+            })
     )
-        .map(|(weight, atlas_file, tag, float1, float2)| Entry {
-            weight,
-            atlas_file,
-            tag,
-            float1,
-            float2,
-        }))
 }
 
 fn header<'a>() -> impl WinnowParser<&'a str, (String, Option<f32>)> {
@@ -37,27 +40,33 @@ fn header<'a>() -> impl WinnowParser<&'a str, (String, Option<f32>)> {
 }
 
 fn group<'a>() -> impl SliceParser<'a, &'a str, Group> {
-    winnow::trace!("group", (
-        lift(header()), //
-        repeat(0.., lift(entry())),
+    winnow::trace!(
+        "group",
+        (
+            lift(header()), //
+            repeat(0.., lift(entry())),
+        )
+            .map(|((area, float), entries)| Group {
+                area,
+                float,
+                entries,
+            })
     )
-        .map(|((area, float), entries)| Group {
-            area,
-            float,
-            entries,
-        }))
 }
 
 fn default_group<'a>() -> impl SliceParser<'a, &'a str, Group> {
-    winnow::trace!("default_group", (
-        lift(literal("Default").map(String::from)), //
-        repeat(0.., lift(entry())),
+    winnow::trace!(
+        "default_group",
+        (
+            lift(literal("Default").map(String::from)), //
+            repeat(0.., lift(entry())),
+        )
+            .map(|(area, entries)| Group {
+                area,
+                float: None,
+                entries,
+            })
     )
-        .map(|(area, entries)| Group {
-            area,
-            float: None,
-            entries,
-        }))
 }
 
 pub fn parse_dct_str(contents: &str) -> Result<DCTFile> {

--- a/src/file_parsers/ddt/parser.rs
+++ b/src/file_parsers/ddt/parser.rs
@@ -9,65 +9,74 @@ use winnow::{
 use super::types::*;
 use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
-    winnow::{
-        WinnowParser, filename, quoted, quoted_str, safe_u32, unquoted_str,
-        version_line,
-    },
+    winnow::{WinnowParser, filename, quoted, quoted_str, safe_u32, unquoted_str, version_line},
 };
 
 fn line1<'a>() -> impl WinnowParser<&'a str, Line1> {
-    winnow::trace!("line1", (
-        F, //
-        opt(P(space1, U)),
-        opt(P(space1, U)),
+    winnow::trace!(
+        "line1",
+        (
+            F, //
+            opt(P(space1, U)),
+            opt(P(space1, U)),
+        )
+            .map(|(scale, uint1, uint2)| Line1 {
+                scale,
+                uint1,
+                uint2,
+            })
     )
-        .map(|(scale, uint1, uint2)| Line1 {
-            scale,
-            uint1,
-            uint2,
-        }))
 }
 
 fn group_header<'a>(
     name_parser: impl WinnowParser<&'a str, String>,
 ) -> impl WinnowParser<&'a str, (String, Option<String>, Option<f32>)> {
-    winnow::trace!("group_header", (
-        name_parser, //
-        opt(P(space1, unquoted_str)),
-        opt(P(space1, F)),
-    ))
+    winnow::trace!(
+        "group_header",
+        (
+            name_parser, //
+            opt(P(space1, unquoted_str)),
+            opt(P(space1, F)),
+        )
+    )
 }
 
 fn object<'a>() -> impl WinnowParser<&'a str, Object> {
-    winnow::trace!("object", (
-        alt((literal("All").map(|_| Weight::All), F.map(Weight::Float))),
-        P(space1, quoted('"').and_then(filename("ao"))),
-        opt(P(space1, safe_u32)),
-        opt(P(space1, literal("D").map(String::from))),
-        opt(P(space1, F)),
+    winnow::trace!(
+        "object",
+        (
+            alt((literal("All").map(|_| Weight::All), F.map(Weight::Float))),
+            P(space1, quoted('"').and_then(filename("ao"))),
+            opt(P(space1, safe_u32)),
+            opt(P(space1, literal("D").map(String::from))),
+            opt(P(space1, F)),
+        )
+            .map(|(weight, ao_file, uint1, d, float1)| Object {
+                weight,
+                ao_file,
+                uint1,
+                d,
+                float1,
+            })
     )
-        .map(|(weight, ao_file, uint1, d, float1)| Object {
-            weight,
-            ao_file,
-            uint1,
-            d,
-            float1,
-        }))
 }
 
 fn group<'a>(
     name_parser: impl WinnowParser<&'a str, String>,
 ) -> impl SliceParser<'a, &'a str, Group> {
-    winnow::trace!("group", (
-        lift(group_header(name_parser)), //
-        repeat(0.., lift(object())),
+    winnow::trace!(
+        "group",
+        (
+            lift(group_header(name_parser)), //
+            repeat(0.., lift(object())),
+        )
+            .map(|((name, d, float1), objects)| Group {
+                name,
+                d,
+                float1,
+                objects,
+            })
     )
-        .map(|((name, d, float1), objects)| Group {
-            name,
-            d,
-            float1,
-            objects,
-        }))
 }
 
 pub fn parse_ddt_str(contents: &str) -> Result<DDTFile> {

--- a/src/file_parsers/ddt/parser.rs
+++ b/src/file_parsers/ddt/parser.rs
@@ -10,13 +10,13 @@ use super::types::*;
 use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
     winnow::{
-        TraceHelper, WinnowParser, filename, quoted, quoted_str, safe_u32, unquoted_str,
+        WinnowParser, filename, quoted, quoted_str, safe_u32, unquoted_str,
         version_line,
     },
 };
 
 fn line1<'a>() -> impl WinnowParser<&'a str, Line1> {
-    (
+    winnow::trace!("line1", (
         F, //
         opt(P(space1, U)),
         opt(P(space1, U)),
@@ -25,23 +25,21 @@ fn line1<'a>() -> impl WinnowParser<&'a str, Line1> {
             scale,
             uint1,
             uint2,
-        })
-        .trace("line1")
+        }))
 }
 
 fn group_header<'a>(
     name_parser: impl WinnowParser<&'a str, String>,
 ) -> impl WinnowParser<&'a str, (String, Option<String>, Option<f32>)> {
-    (
+    winnow::trace!("group_header", (
         name_parser, //
         opt(P(space1, unquoted_str)),
         opt(P(space1, F)),
-    )
-        .trace("group_header")
+    ))
 }
 
 fn object<'a>() -> impl WinnowParser<&'a str, Object> {
-    (
+    winnow::trace!("object", (
         alt((literal("All").map(|_| Weight::All), F.map(Weight::Float))),
         P(space1, quoted('"').and_then(filename("ao"))),
         opt(P(space1, safe_u32)),
@@ -54,14 +52,13 @@ fn object<'a>() -> impl WinnowParser<&'a str, Object> {
             uint1,
             d,
             float1,
-        })
-        .trace("object")
+        }))
 }
 
 fn group<'a>(
     name_parser: impl WinnowParser<&'a str, String>,
 ) -> impl SliceParser<'a, &'a str, Group> {
-    (
+    winnow::trace!("group", (
         lift(group_header(name_parser)), //
         repeat(0.., lift(object())),
     )
@@ -70,8 +67,7 @@ fn group<'a>(
             d,
             float1,
             objects,
-        })
-        .trace("group")
+        }))
 }
 
 pub fn parse_ddt_str(contents: &str) -> Result<DDTFile> {

--- a/src/file_parsers/dlp/parser.rs
+++ b/src/file_parsers/dlp/parser.rs
@@ -16,43 +16,46 @@ use crate::file_parsers::shared::{
 };
 
 fn headers_v2<'a>() -> impl WinnowParser<&'a str, HeadersV2> {
-    winnow::trace!("headers_v2", (
-        float, //
-        P(space1, float),
-        P(space1, parse_bool),
-        P(space1, parse_bool),
-        opt(P(space1, dec_uint)),
-        opt(P(space1, dec_uint)),
-        opt(P(space1, dec_uint)),
-        opt(P(space1, float)),
-        opt(P(space1, dec_uint)),
-        opt(P(space1, float)),
+    winnow::trace!(
+        "headers_v2",
+        (
+            float, //
+            P(space1, float),
+            P(space1, parse_bool),
+            P(space1, parse_bool),
+            opt(P(space1, dec_uint)),
+            opt(P(space1, dec_uint)),
+            opt(P(space1, dec_uint)),
+            opt(P(space1, float)),
+            opt(P(space1, dec_uint)),
+            opt(P(space1, float)),
+        )
+            .map(
+                |(
+                    scale_min,
+                    scale_max,
+                    allow_waving,
+                    allow_on_blocking,
+                    max_rotation,
+                    uint1,
+                    uint2,
+                    float1,
+                    audio_type,
+                    float2,
+                )| HeadersV2 {
+                    scale_min,
+                    scale_max,
+                    allow_waving,
+                    allow_on_blocking,
+                    max_rotation,
+                    uint1,
+                    uint2,
+                    float1,
+                    audio_type,
+                    float2,
+                },
+            )
     )
-        .map(
-            |(
-                scale_min,
-                scale_max,
-                allow_waving,
-                allow_on_blocking,
-                max_rotation,
-                uint1,
-                uint2,
-                float1,
-                audio_type,
-                float2,
-            )| HeadersV2 {
-                scale_min,
-                scale_max,
-                allow_waving,
-                allow_on_blocking,
-                max_rotation,
-                uint1,
-                uint2,
-                float1,
-                audio_type,
-                float2,
-            },
-        ))
 }
 
 fn headers_v3<'a>() -> impl SliceParser<'a, &'a str, HeadersV3> {
@@ -80,33 +83,36 @@ fn headers_v3<'a>() -> impl SliceParser<'a, &'a str, HeadersV3> {
 }
 
 fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
-    winnow::trace!("entry", (
-        quoted('"').and_then(filename("fmt")), //
-        P(space1, float),
-        repeat(
-            0..,
-            P(
-                space1,
-                alt((
-                    delimited(
-                        literal('('),
-                        separated_pair(float, literal(','), float),
-                        literal(')'),
-                    ),
-                    delimited(
-                        literal('['),
-                        separated_pair(float, space1, float),
-                        literal(']'),
-                    ),
-                )),
+    winnow::trace!(
+        "entry",
+        (
+            quoted('"').and_then(filename("fmt")), //
+            P(space1, float),
+            repeat(
+                0..,
+                P(
+                    space1,
+                    alt((
+                        delimited(
+                            literal('('),
+                            separated_pair(float, literal(','), float),
+                            literal(')'),
+                        ),
+                        delimited(
+                            literal('['),
+                            separated_pair(float, space1, float),
+                            literal(']'),
+                        ),
+                    )),
+                ),
             ),
-        ),
+        )
+            .map(|(fmt_file, float, points)| Entry {
+                fmt_file,
+                float,
+                points,
+            })
     )
-        .map(|(fmt_file, float, points)| Entry {
-            fmt_file,
-            float,
-            points,
-        }))
 }
 
 pub fn parse_dlp_str(contents: &str) -> Result<DLPFile> {

--- a/src/file_parsers/dlp/parser.rs
+++ b/src/file_parsers/dlp/parser.rs
@@ -12,11 +12,11 @@ use winnow::{
 use super::types::*;
 use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
-    winnow::{TraceHelper, WinnowParser, filename, parse_bool, quoted, unquoted, version_line},
+    winnow::{WinnowParser, filename, parse_bool, quoted, unquoted, version_line},
 };
 
 fn headers_v2<'a>() -> impl WinnowParser<&'a str, HeadersV2> {
-    (
+    winnow::trace!("headers_v2", (
         float, //
         P(space1, float),
         P(space1, parse_bool),
@@ -52,12 +52,11 @@ fn headers_v2<'a>() -> impl WinnowParser<&'a str, HeadersV2> {
                 audio_type,
                 float2,
             },
-        )
-        .trace("headers_v2")
+        ))
 }
 
 fn headers_v3<'a>() -> impl SliceParser<'a, &'a str, HeadersV3> {
-    repeat(
+    winnow::trace!("headers_v3", repeat(
         0..,
         lift(P(
             (literal('-'), space1),
@@ -77,12 +76,11 @@ fn headers_v3<'a>() -> impl SliceParser<'a, &'a str, HeadersV3> {
             },
         )),
     )
-    .map(HeadersV3)
-    .trace("headers_v3")
+    .map(HeadersV3))
 }
 
 fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
-    (
+    winnow::trace!("entry", (
         quoted('"').and_then(filename("fmt")), //
         P(space1, float),
         repeat(
@@ -108,8 +106,7 @@ fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
             fmt_file,
             float,
             points,
-        })
-        .trace("entry")
+        }))
 }
 
 pub fn parse_dlp_str(contents: &str) -> Result<DLPFile> {

--- a/src/file_parsers/ecf/parser.rs
+++ b/src/file_parsers/ecf/parser.rs
@@ -12,11 +12,14 @@ use crate::file_parsers::shared::{
 };
 
 fn combination<'a>() -> impl WinnowParser<&'a str, EcfCombination> {
-    winnow::trace!("combination", (
-        separated_array(space1, quoted('"').and_then(optional_filename("et"))),
-        opt(preceded(space1, dec_uint)),
+    winnow::trace!(
+        "combination",
+        (
+            separated_array(space1, quoted('"').and_then(optional_filename("et"))),
+            opt(preceded(space1, dec_uint)),
+        )
+            .map(|(et_files, uint1)| EcfCombination { et_files, uint1 })
     )
-        .map(|(et_files, uint1)| EcfCombination { et_files, uint1 }))
 }
 
 pub fn parse_ecf_str(contents: &str) -> Result<EcfFile> {

--- a/src/file_parsers/ecf/parser.rs
+++ b/src/file_parsers/ecf/parser.rs
@@ -8,16 +8,15 @@ use winnow::{
 use super::types::*;
 use crate::file_parsers::shared::{
     lift::lift,
-    winnow::{TraceHelper, WinnowParser, optional_filename, quoted, separated_array, version_line},
+    winnow::{WinnowParser, optional_filename, quoted, separated_array, version_line},
 };
 
 fn combination<'a>() -> impl WinnowParser<&'a str, EcfCombination> {
-    (
+    winnow::trace!("combination", (
         separated_array(space1, quoted('"').and_then(optional_filename("et"))),
         opt(preceded(space1, dec_uint)),
     )
-        .map(|(et_files, uint1)| EcfCombination { et_files, uint1 })
-        .trace("combination")
+        .map(|(et_files, uint1)| EcfCombination { et_files, uint1 }))
 }
 
 pub fn parse_ecf_str(contents: &str) -> Result<EcfFile> {

--- a/src/file_parsers/epk/parser.rs
+++ b/src/file_parsers/epk/parser.rs
@@ -16,115 +16,122 @@ use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
     remove_trailing,
     winnow::{
-        WinnowParser, filename, nullable_uint, quoted, quoted_comma_separated,
-        quoted_str, repeat_array, unquoted, unquoted_str,
+        WinnowParser, filename, nullable_uint, quoted, quoted_comma_separated, quoted_str,
+        repeat_array, unquoted, unquoted_str,
     },
 };
 
 pub fn render_passes<'a>() -> impl SliceParser<'a, &'a str, Effect> {
-    let single_line = winnow::trace!("single_line", (
-        literal("RenderPasses"),
-        space1,
-        literal("{"),
-        space0,
-        literal("}"),
-    )
-        .value(Effect::RenderPasses(RenderPasses { passes: vec![] })));
-
-    let multiline = winnow::trace!("multi_line", P(
-        lift(literal("RenderPasses").map(String::from)),
+    let single_line = winnow::trace!(
+        "single_line",
         (
-            lift(literal("{")),
-            repeat_till(.., lift(rest), lift(literal("}"))),
+            literal("RenderPasses"),
+            space1,
+            literal("{"),
+            space0,
+            literal("}"),
         )
-            .map(|(b0, (middle, b1)): (&str, (Vec<&str>, &str))| {
-                [[b0].as_slice(), &middle, &[b1]].concat().concat()
-            }),
-    )
-    .try_map(|payload| {
-        let payload = remove_trailing(&payload);
-        serde_json::from_str(&payload)
-    })
-    .map(Effect::RenderPasses));
+            .value(Effect::RenderPasses(RenderPasses { passes: vec![] }))
+    );
 
-    winnow::trace!("RenderPasses", alt((
-        lift(single_line), //
-        multiline,
-    )))
+    let multiline = winnow::trace!(
+        "multi_line",
+        P(
+            lift(literal("RenderPasses").map(String::from)),
+            (
+                lift(literal("{")),
+                repeat_till(.., lift(rest), lift(literal("}"))),
+            )
+                .map(|(b0, (middle, b1)): (&str, (Vec<&str>, &str))| {
+                    [[b0].as_slice(), &middle, &[b1]].concat().concat()
+                }),
+        )
+        .try_map(|payload| {
+            let payload = remove_trailing(&payload);
+            serde_json::from_str(&payload)
+        })
+        .map(Effect::RenderPasses)
+    );
+
+    winnow::trace!(
+        "RenderPasses",
+        alt((
+            lift(single_line), //
+            multiline,
+        ))
+    )
 }
 
 pub fn attached_object<'a>() -> impl WinnowParser<&'a str, Effect> {
-    winnow::trace!("AttachedObject", (
-        quoted_str, //
-        // NOTE: Edge case: missing space between these two strings
-        P(space0, quoted('"').and_then(filename("ao"))),
-        opt(P(space1, literal("\"ignore_errors\""))).map(|x| x.is_some()),
+    winnow::trace!(
+        "AttachedObject",
+        (
+            quoted_str, //
+            // NOTE: Edge case: missing space between these two strings
+            P(space0, quoted('"').and_then(filename("ao"))),
+            opt(P(space1, literal("\"ignore_errors\""))).map(|x| x.is_some()),
+        )
+            .map(
+                |(attachment_point, ao_file, ignore_errors)| Effect::AttachedObject {
+                    attachment_point,
+                    ao_file,
+                    ignore_errors,
+                },
+            )
     )
-        .map(
-            |(attachment_point, ao_file, ignore_errors)| Effect::AttachedObject {
-                attachment_point,
-                ao_file,
-                ignore_errors,
-            },
-        ))
 }
 
 pub fn particle_effect<'a>() -> impl WinnowParser<&'a str, Effect> {
-    winnow::trace!("ParticleEffect", (
-        quoted_str,
-        P(space1, quoted('"').and_then(filename("pet"))),
-        opt(P(
-            (space1, literal("\"limit\"")), //
-            repeat_array(P(space1, dec_uint)),
-        )),
-        opt(P(space1, literal("\"ignore_errors\""))).map(|x| x.is_some()),
+    winnow::trace!(
+        "ParticleEffect",
+        (
+            quoted_str,
+            P(space1, quoted('"').and_then(filename("pet"))),
+            opt(P(
+                (space1, literal("\"limit\"")), //
+                repeat_array(P(space1, dec_uint)),
+            )),
+            opt(P(space1, literal("\"ignore_errors\""))).map(|x| x.is_some()),
+        )
+            .map(
+                |(glob, pet_file, limit, ignore_errors)| Effect::ParticleEffect {
+                    glob,
+                    pet_file,
+                    limit,
+                    ignore_errors,
+                },
+            )
     )
-        .map(
-            |(glob, pet_file, limit, ignore_errors)| Effect::ParticleEffect {
-                glob,
-                pet_file,
-                limit,
-                ignore_errors,
-            },
-        ))
 }
 
 pub fn attached_object_ex<'a>() -> impl WinnowParser<&'a str, Effect> {
-    winnow::trace!("AttachedObjectEx", (
-        opt(T(quoted_str, space1)),
-        length_repeat(
-            dec_uint::<_, u32, _>,
-            P(
-                space1,
-                quoted('"').and_then(alt((
-                    filename("ao"), //
-                    filename("fmt"),
-                ))),
-            ),
-        ),
-        repeat_array(P(space1, dec_uint)),
-        repeat_array(P(space1, float)),
+    winnow::trace!(
+        "AttachedObjectEx",
         (
-            opt(P(space1, dec_int)), //
-            opt(P(space1, dec_int)),
+            opt(T(quoted_str, space1)),
+            length_repeat(
+                dec_uint::<_, u32, _>,
+                P(
+                    space1,
+                    quoted('"').and_then(alt((
+                        filename("ao"), //
+                        filename("fmt"),
+                    ))),
+                ),
+            ),
+            repeat_array(P(space1, dec_uint)),
+            repeat_array(P(space1, float)),
+            (
+                opt(P(space1, dec_int)), //
+                opt(P(space1, dec_int)),
+            )
+                .map(|(r0, r1)| [r0, r1]),
+            opt(P(space1, literal("\"include_aux\""))).map(|x| x.is_some()),
+            opt(P(space1, literal("\"multi_attach\""))).map(|x| x.is_some()),
+            opt(P(space1, literal("\"ignore_errors\""))).map(|x| x.is_some()),
         )
-            .map(|(r0, r1)| [r0, r1]),
-        opt(P(space1, literal("\"include_aux\""))).map(|x| x.is_some()),
-        opt(P(space1, literal("\"multi_attach\""))).map(|x| x.is_some()),
-        opt(P(space1, literal("\"ignore_errors\""))).map(|x| x.is_some()),
-    )
-        .map(
-            |(
-                attachment_point,
-                files,
-                uints1,
-                floats,
-                rotations,
-                include_aux,
-                ignore_errors,
-                multi_attach,
-            )| {
-                Effect::AttachedObjectEx {
+            .map(
+                |(
                     attachment_point,
                     files,
                     uints1,
@@ -133,20 +140,34 @@ pub fn attached_object_ex<'a>() -> impl WinnowParser<&'a str, Effect> {
                     include_aux,
                     ignore_errors,
                     multi_attach,
-                }
-            },
-        ))
+                )| {
+                    Effect::AttachedObjectEx {
+                        attachment_point,
+                        files,
+                        uints1,
+                        floats,
+                        rotations,
+                        include_aux,
+                        ignore_errors,
+                        multi_attach,
+                    }
+                },
+            )
+    )
 }
 
 pub fn attached_object_bone_index<'a>() -> impl WinnowParser<&'a str, Effect> {
-    winnow::trace!("AttachedObject", (
-        dec_uint, //
-        P(space1, quoted('"').and_then(filename("ao"))),
+    winnow::trace!(
+        "AttachedObject",
+        (
+            dec_uint, //
+            P(space1, quoted('"').and_then(filename("ao"))),
+        )
+            .map(|(bone_index, ao_file)| Effect::AttachedObjectBoneIndex {
+                bone_index,
+                ao_file,
+            })
     )
-        .map(|(bone_index, ao_file)| Effect::AttachedObjectBoneIndex {
-            bone_index,
-            ao_file,
-        }))
 }
 
 /// to/from_bone to/from_bone_index
@@ -202,10 +223,13 @@ pub fn bone<'a, const FROM: bool>() -> impl WinnowParser<&'a str, Bone> {
             }
         });
 
-    winnow::trace!("bone", alt((
-        parent_parser, //
-        child_parser,
-    )))
+    winnow::trace!(
+        "bone",
+        alt((
+            parent_parser, //
+            child_parser,
+        ))
+    )
 }
 
 pub fn child_attached_object<'a>() -> impl WinnowParser<&'a str, Effect> {
@@ -224,116 +248,143 @@ pub fn child_attached_object<'a>() -> impl WinnowParser<&'a str, Effect> {
 }
 
 pub fn trail_effect<'a>() -> impl WinnowParser<&'a str, Effect> {
-    winnow::trace!("TrailEffect", (
-        quoted_str,
-        P(space1, quoted('"').and_then(filename("trl"))),
-        opt(P(
-            (space1, literal("\"limit\"")), //
-            repeat_array(P(space1, dec_uint)),
-        )),
-        opt(P(space1, literal("\"ignore_errors\""))).map(|x| x.is_some()),
+    winnow::trace!(
+        "TrailEffect",
+        (
+            quoted_str,
+            P(space1, quoted('"').and_then(filename("trl"))),
+            opt(P(
+                (space1, literal("\"limit\"")), //
+                repeat_array(P(space1, dec_uint)),
+            )),
+            opt(P(space1, literal("\"ignore_errors\""))).map(|x| x.is_some()),
+        )
+            .map(
+                |(glob, trl_file, limit, ignore_errors)| Effect::TrailEffect {
+                    glob,
+                    trl_file,
+                    limit,
+                    ignore_errors,
+                },
+            )
     )
-        .map(
-            |(glob, trl_file, limit, ignore_errors)| Effect::TrailEffect {
-                glob,
-                trl_file,
-                limit,
-                ignore_errors,
-            },
-        ))
 }
 
 pub fn hide_first_pass_after_delay<'a>() -> impl WinnowParser<&'a str, Effect> {
-    winnow::trace!("HideFirstPassAfterDelay", float
-        .map(|delay| Effect::HideFirstPassAfterDelay { delay }))
+    winnow::trace!(
+        "HideFirstPassAfterDelay",
+        float.map(|delay| Effect::HideFirstPassAfterDelay { delay })
+    )
 }
 
 pub fn hide_first_pass_after_delay_for_duration<'a>() -> impl WinnowParser<&'a str, Effect> {
-    winnow::trace!("HideFirstPassAfterDelayForDuration", separated_pair(float, space1, float)
-        .map(|(delay, duration)| Effect::HideFirstPassAfterDelayForDuration { delay, duration }))
+    winnow::trace!(
+        "HideFirstPassAfterDelayForDuration",
+        separated_pair(float, space1, float).map(|(delay, duration)| {
+            Effect::HideFirstPassAfterDelayForDuration { delay, duration }
+        })
+    )
 }
 
 pub fn hide_first_pass_using_epk_parameter<'a>() -> impl WinnowParser<&'a str, Effect> {
-    winnow::trace!("HideFirstPassUsingEPKParameter", (
-        unquoted_str, //
-        P(space1, float),
-        P(space1, float),
+    winnow::trace!(
+        "HideFirstPassUsingEPKParameter",
+        (
+            unquoted_str, //
+            P(space1, float),
+            P(space1, float),
+        )
+            .map(
+                |(parameter, float1, float2)| Effect::HideFirstPassUsingEPKParameter {
+                    parameter,
+                    float1,
+                    float2,
+                },
+            )
     )
-        .map(
-            |(parameter, float1, float2)| Effect::HideFirstPassUsingEPKParameter {
-                parameter,
-                float1,
-                float2,
-            },
-        ))
 }
 
 pub fn hide_first_pass_using_timeline_parameter<'a>() -> impl WinnowParser<&'a str, Effect> {
-    winnow::trace!("HideFirstPassUsingTimelineParameter", (
-        unquoted_str, //
-        P(space1, float),
-        P(space1, float),
+    winnow::trace!(
+        "HideFirstPassUsingTimelineParameter",
+        (
+            unquoted_str, //
+            P(space1, float),
+            P(space1, float),
+        )
+            .map(|(parameter, float1, float2)| {
+                Effect::HideFirstPassUsingTimelineParameter {
+                    parameter,
+                    float1,
+                    float2,
+                }
+            },)
     )
-        .map(
-            |(parameter, float1, float2)| Effect::HideFirstPassUsingTimelineParameter {
-                parameter,
-                float1,
-                float2,
-            },
-        ))
 }
 
 pub fn hide_first_pass_using_dynamic_parameter<'a>() -> impl WinnowParser<&'a str, Effect> {
-    winnow::trace!("HideFirstPassUsingDynamicParameter", (
-        unquoted_str, //
-        P(space1, float),
-        P(space1, float),
+    winnow::trace!(
+        "HideFirstPassUsingDynamicParameter",
+        (
+            unquoted_str, //
+            P(space1, float),
+            P(space1, float),
+        )
+            .map(|(parameter, float1, float2)| {
+                Effect::HideFirstPassUsingDynamicParameter {
+                    parameter,
+                    float1,
+                    float2,
+                }
+            },)
     )
-        .map(
-            |(parameter, float1, float2)| Effect::HideFirstPassUsingDynamicParameter {
-                parameter,
-                float1,
-                float2,
-            },
-        ))
 }
 
 pub fn play_misc_effect_pack_after_delay<'a>() -> impl WinnowParser<&'a str, Effect> {
-    winnow::trace!("PlayMiscEffectPackAfterDelay", separated_pair(quoted_str, space1, float)
-        .map(|(effect, delay)| Effect::PlayMiscEffectPackAfterDelay { effect, delay }))
+    winnow::trace!(
+        "PlayMiscEffectPackAfterDelay",
+        separated_pair(quoted_str, space1, float)
+            .map(|(effect, delay)| Effect::PlayMiscEffectPackAfterDelay { effect, delay })
+    )
 }
 
 pub fn other_effect<'a>(name: &str) -> impl WinnowParser<&'a str, Effect> {
-    winnow::trace!("other_effect", rest.map(|rest: &str| Effect::Other {
-        name: name.to_string(),
-        rest: rest.to_string(),
-    }))
+    winnow::trace!(
+        "other_effect",
+        rest.map(|rest: &str| Effect::Other {
+            name: name.to_string(),
+            rest: rest.to_string(),
+        })
+    )
 }
 
 pub fn effect<'a>() -> impl SliceParser<'a, &'a str, Effect> {
-    winnow::trace!("effect", alt((
-        render_passes(),
-        lift(dispatch! {
-            T(unquoted(), opt(space1));
-            "AttachedObject" => attached_object(),
-            "AttachedObjectEx" => attached_object_ex(),
-            "AttachedObjectBoneIndex" => attached_object_bone_index(),
-            "ChildAttachedObject" => child_attached_object(),
-            "ParticleEffect" => particle_effect(),
-            "TrailEffect" => trail_effect(),
-            "ParentOnlyEffects" => eof.map(|_| Effect::ParentOnlyEffects),
-            "ApplyToAllPasses" => eof.map(|_| Effect::ApplyToAllPasses),
-            "PlayMiscEffectPackOnEnd" => quoted_str.map(|effect| Effect::PlayMiscEffectPackOnEnd { effect }),
-            "PlayMiscEffectPackOnBegin" => quoted_str.map(|effect| Effect::PlayMiscEffectPackOnBegin { effect }),
-            "PlayMiscEffectPackAfterDelay" => play_misc_effect_pack_after_delay(),
-            "HideFirstPassAfterDelay" => hide_first_pass_after_delay(),
-            "HideFirstPassAfterDelayForDuration" => hide_first_pass_after_delay_for_duration(),
-            "HideFirstPassUsingEPKParameter" => hide_first_pass_using_epk_parameter(),
-            "HideFirstPassUsingTimelineParameter" => hide_first_pass_using_timeline_parameter(),
-            "HideFirstPassUsingDynamicParameter" => hide_first_pass_using_dynamic_parameter(),
-            name => other_effect(name),
-        }),
-    )))
+    winnow::trace!(
+        "effect",
+        alt((
+            render_passes(),
+            lift(dispatch! {
+                T(unquoted(), opt(space1));
+                "AttachedObject" => attached_object(),
+                "AttachedObjectEx" => attached_object_ex(),
+                "AttachedObjectBoneIndex" => attached_object_bone_index(),
+                "ChildAttachedObject" => child_attached_object(),
+                "ParticleEffect" => particle_effect(),
+                "TrailEffect" => trail_effect(),
+                "ParentOnlyEffects" => eof.map(|_| Effect::ParentOnlyEffects),
+                "ApplyToAllPasses" => eof.map(|_| Effect::ApplyToAllPasses),
+                "PlayMiscEffectPackOnEnd" => quoted_str.map(|effect| Effect::PlayMiscEffectPackOnEnd { effect }),
+                "PlayMiscEffectPackOnBegin" => quoted_str.map(|effect| Effect::PlayMiscEffectPackOnBegin { effect }),
+                "PlayMiscEffectPackAfterDelay" => play_misc_effect_pack_after_delay(),
+                "HideFirstPassAfterDelay" => hide_first_pass_after_delay(),
+                "HideFirstPassAfterDelayForDuration" => hide_first_pass_after_delay_for_duration(),
+                "HideFirstPassUsingEPKParameter" => hide_first_pass_using_epk_parameter(),
+                "HideFirstPassUsingTimelineParameter" => hide_first_pass_using_timeline_parameter(),
+                "HideFirstPassUsingDynamicParameter" => hide_first_pass_using_dynamic_parameter(),
+                name => other_effect(name),
+            }),
+        ))
+    )
 }
 
 pub fn parse_epk_str(contents: &str) -> Result<EPKFile> {

--- a/src/file_parsers/epk/parser.rs
+++ b/src/file_parsers/epk/parser.rs
@@ -16,23 +16,22 @@ use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
     remove_trailing,
     winnow::{
-        TraceHelper, WinnowParser, filename, nullable_uint, quoted, quoted_comma_separated,
+        WinnowParser, filename, nullable_uint, quoted, quoted_comma_separated,
         quoted_str, repeat_array, unquoted, unquoted_str,
     },
 };
 
 pub fn render_passes<'a>() -> impl SliceParser<'a, &'a str, Effect> {
-    let single_line = (
+    let single_line = winnow::trace!("single_line", (
         literal("RenderPasses"),
         space1,
         literal("{"),
         space0,
         literal("}"),
     )
-        .value(Effect::RenderPasses(RenderPasses { passes: vec![] }))
-        .trace("single_line");
+        .value(Effect::RenderPasses(RenderPasses { passes: vec![] })));
 
-    let multiline = P(
+    let multiline = winnow::trace!("multi_line", P(
         lift(literal("RenderPasses").map(String::from)),
         (
             lift(literal("{")),
@@ -46,18 +45,16 @@ pub fn render_passes<'a>() -> impl SliceParser<'a, &'a str, Effect> {
         let payload = remove_trailing(&payload);
         serde_json::from_str(&payload)
     })
-    .map(Effect::RenderPasses)
-    .trace("multi_line");
+    .map(Effect::RenderPasses));
 
-    alt((
+    winnow::trace!("RenderPasses", alt((
         lift(single_line), //
         multiline,
-    ))
-    .trace("RenderPasses")
+    )))
 }
 
 pub fn attached_object<'a>() -> impl WinnowParser<&'a str, Effect> {
-    (
+    winnow::trace!("AttachedObject", (
         quoted_str, //
         // NOTE: Edge case: missing space between these two strings
         P(space0, quoted('"').and_then(filename("ao"))),
@@ -69,12 +66,11 @@ pub fn attached_object<'a>() -> impl WinnowParser<&'a str, Effect> {
                 ao_file,
                 ignore_errors,
             },
-        )
-        .trace("AttachedObject")
+        ))
 }
 
 pub fn particle_effect<'a>() -> impl WinnowParser<&'a str, Effect> {
-    (
+    winnow::trace!("ParticleEffect", (
         quoted_str,
         P(space1, quoted('"').and_then(filename("pet"))),
         opt(P(
@@ -90,12 +86,11 @@ pub fn particle_effect<'a>() -> impl WinnowParser<&'a str, Effect> {
                 limit,
                 ignore_errors,
             },
-        )
-        .trace("ParticleEffect")
+        ))
 }
 
 pub fn attached_object_ex<'a>() -> impl WinnowParser<&'a str, Effect> {
-    (
+    winnow::trace!("AttachedObjectEx", (
         opt(T(quoted_str, space1)),
         length_repeat(
             dec_uint::<_, u32, _>,
@@ -140,20 +135,18 @@ pub fn attached_object_ex<'a>() -> impl WinnowParser<&'a str, Effect> {
                     multi_attach,
                 }
             },
-        )
-        .trace("AttachedObjectEx")
+        ))
 }
 
 pub fn attached_object_bone_index<'a>() -> impl WinnowParser<&'a str, Effect> {
-    (
+    winnow::trace!("AttachedObject", (
         dec_uint, //
         P(space1, quoted('"').and_then(filename("ao"))),
     )
         .map(|(bone_index, ao_file)| Effect::AttachedObjectBoneIndex {
             bone_index,
             ao_file,
-        })
-        .trace("AttachedObject")
+        }))
 }
 
 /// to/from_bone to/from_bone_index
@@ -209,11 +202,10 @@ pub fn bone<'a, const FROM: bool>() -> impl WinnowParser<&'a str, Bone> {
             }
         });
 
-    alt((
+    winnow::trace!("bone", alt((
         parent_parser, //
         child_parser,
-    ))
-    .trace("bone")
+    )))
 }
 
 pub fn child_attached_object<'a>() -> impl WinnowParser<&'a str, Effect> {
@@ -232,7 +224,7 @@ pub fn child_attached_object<'a>() -> impl WinnowParser<&'a str, Effect> {
 }
 
 pub fn trail_effect<'a>() -> impl WinnowParser<&'a str, Effect> {
-    (
+    winnow::trace!("TrailEffect", (
         quoted_str,
         P(space1, quoted('"').and_then(filename("trl"))),
         opt(P(
@@ -248,24 +240,21 @@ pub fn trail_effect<'a>() -> impl WinnowParser<&'a str, Effect> {
                 limit,
                 ignore_errors,
             },
-        )
-        .trace("TrailEffect")
+        ))
 }
 
 pub fn hide_first_pass_after_delay<'a>() -> impl WinnowParser<&'a str, Effect> {
-    float
-        .map(|delay| Effect::HideFirstPassAfterDelay { delay })
-        .trace("HideFirstPassAfterDelay")
+    winnow::trace!("HideFirstPassAfterDelay", float
+        .map(|delay| Effect::HideFirstPassAfterDelay { delay }))
 }
 
 pub fn hide_first_pass_after_delay_for_duration<'a>() -> impl WinnowParser<&'a str, Effect> {
-    separated_pair(float, space1, float)
-        .map(|(delay, duration)| Effect::HideFirstPassAfterDelayForDuration { delay, duration })
-        .trace("HideFirstPassAfterDelayForDuration")
+    winnow::trace!("HideFirstPassAfterDelayForDuration", separated_pair(float, space1, float)
+        .map(|(delay, duration)| Effect::HideFirstPassAfterDelayForDuration { delay, duration }))
 }
 
 pub fn hide_first_pass_using_epk_parameter<'a>() -> impl WinnowParser<&'a str, Effect> {
-    (
+    winnow::trace!("HideFirstPassUsingEPKParameter", (
         unquoted_str, //
         P(space1, float),
         P(space1, float),
@@ -276,12 +265,11 @@ pub fn hide_first_pass_using_epk_parameter<'a>() -> impl WinnowParser<&'a str, E
                 float1,
                 float2,
             },
-        )
-        .trace("HideFirstPassUsingEPKParameter")
+        ))
 }
 
 pub fn hide_first_pass_using_timeline_parameter<'a>() -> impl WinnowParser<&'a str, Effect> {
-    (
+    winnow::trace!("HideFirstPassUsingTimelineParameter", (
         unquoted_str, //
         P(space1, float),
         P(space1, float),
@@ -292,12 +280,11 @@ pub fn hide_first_pass_using_timeline_parameter<'a>() -> impl WinnowParser<&'a s
                 float1,
                 float2,
             },
-        )
-        .trace("HideFirstPassUsingTimelineParameter")
+        ))
 }
 
 pub fn hide_first_pass_using_dynamic_parameter<'a>() -> impl WinnowParser<&'a str, Effect> {
-    (
+    winnow::trace!("HideFirstPassUsingDynamicParameter", (
         unquoted_str, //
         P(space1, float),
         P(space1, float),
@@ -308,26 +295,23 @@ pub fn hide_first_pass_using_dynamic_parameter<'a>() -> impl WinnowParser<&'a st
                 float1,
                 float2,
             },
-        )
-        .trace("HideFirstPassUsingDynamicParameter")
+        ))
 }
 
 pub fn play_misc_effect_pack_after_delay<'a>() -> impl WinnowParser<&'a str, Effect> {
-    separated_pair(quoted_str, space1, float)
-        .map(|(effect, delay)| Effect::PlayMiscEffectPackAfterDelay { effect, delay })
-        .trace("PlayMiscEffectPackAfterDelay")
+    winnow::trace!("PlayMiscEffectPackAfterDelay", separated_pair(quoted_str, space1, float)
+        .map(|(effect, delay)| Effect::PlayMiscEffectPackAfterDelay { effect, delay }))
 }
 
 pub fn other_effect<'a>(name: &str) -> impl WinnowParser<&'a str, Effect> {
-    rest.map(|rest: &str| Effect::Other {
+    winnow::trace!("other_effect", rest.map(|rest: &str| Effect::Other {
         name: name.to_string(),
         rest: rest.to_string(),
-    })
-    .trace("other_effect")
+    }))
 }
 
 pub fn effect<'a>() -> impl SliceParser<'a, &'a str, Effect> {
-    alt((
+    winnow::trace!("effect", alt((
         render_passes(),
         lift(dispatch! {
             T(unquoted(), opt(space1));
@@ -349,8 +333,7 @@ pub fn effect<'a>() -> impl SliceParser<'a, &'a str, Effect> {
             "HideFirstPassUsingDynamicParameter" => hide_first_pass_using_dynamic_parameter(),
             name => other_effect(name),
         }),
-    ))
-    .trace("effect")
+    )))
 }
 
 pub fn parse_epk_str(contents: &str) -> Result<EPKFile> {

--- a/src/file_parsers/et/parser.rs
+++ b/src/file_parsers/et/parser.rs
@@ -11,7 +11,7 @@ use super::types::*;
 use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
     winnow::{
-        TraceHelper, WinnowParser, filename, parse_bool, quoted, repeat_array, separated_array,
+        WinnowParser, filename, parse_bool, quoted, repeat_array, separated_array,
         unquoted, unquoted_str,
     },
 };
@@ -19,11 +19,11 @@ use crate::file_parsers::shared::{
 fn name_hex<'a>() -> impl WinnowParser<&'a str, (String, Option<String>)> {
     let hex_parser = P(literal("#"), take_while(1.., AsChar::is_hex_digit)).map(String::from);
 
-    (unquoted_str, opt(P(space1, hex_parser))).trace("name_hex")
+    winnow::trace!("name_hex", (unquoted_str, opt(P(space1, hex_parser))))
 }
 
 fn gt_files<'a>() -> impl SliceParser<'a, &'a str, [GTFile; 2]> {
-    repeat_array(lift(
+    winnow::trace!("gt_files", repeat_array(lift(
         alt((
             quoted('"'), //
             unquoted(),
@@ -32,12 +32,11 @@ fn gt_files<'a>() -> impl SliceParser<'a, &'a str, [GTFile; 2]> {
             literal("wildcard").map(|_| GTFile::Wildcard),
             filename("gt").map(GTFile::Path),
         ))),
-    ))
-    .trace("gt_files")
+    )))
 }
 
 fn num_line<'a>() -> impl WinnowParser<&'a str, NumLine> {
-    (
+    winnow::trace!("num_line", (
         U,
         P(space1, U),
         P(space1, parse_bool),
@@ -52,22 +51,20 @@ fn num_line<'a>() -> impl WinnowParser<&'a str, NumLine> {
             bool2,
             bool3,
             bool4,
-        })
-        .trace("num_line")
+        }))
 }
 
 fn virtual_et_file<'a>() -> impl WinnowParser<&'a str, VirtualETFile> {
-    separated_pair(
+    winnow::trace!("virtual_et_file", separated_pair(
         unquoted().and_then(filename("et")), //
         space1,
         parse_bool,
     )
-    .map(|(path, bool1)| VirtualETFile { path, bool1 })
-    .trace("virtual_et_file")
+    .map(|(path, bool1)| VirtualETFile { path, bool1 }))
 }
 
 fn virtual_section<'a>() -> impl SliceParser<'a, &'a str, VirtualSection> {
-    (
+    winnow::trace!("virtual_section", (
         lift(literal("virtual")),
         repeat_array(lift(virtual_et_file())),
         lift(separated_array(space1, U)),
@@ -77,8 +74,7 @@ fn virtual_section<'a>() -> impl SliceParser<'a, &'a str, VirtualSection> {
                 virtual_et_files,
                 virtual_rotations,
             },
-        )
-        .trace("virtual_section")
+        ))
 }
 
 pub fn parse_et_str(contents: &str) -> Result<ETFile> {

--- a/src/file_parsers/et/parser.rs
+++ b/src/file_parsers/et/parser.rs
@@ -11,8 +11,8 @@ use super::types::*;
 use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
     winnow::{
-        WinnowParser, filename, parse_bool, quoted, repeat_array, separated_array,
-        unquoted, unquoted_str,
+        WinnowParser, filename, parse_bool, quoted, repeat_array, separated_array, unquoted,
+        unquoted_str,
     },
 };
 
@@ -23,58 +23,70 @@ fn name_hex<'a>() -> impl WinnowParser<&'a str, (String, Option<String>)> {
 }
 
 fn gt_files<'a>() -> impl SliceParser<'a, &'a str, [GTFile; 2]> {
-    winnow::trace!("gt_files", repeat_array(lift(
-        alt((
-            quoted('"'), //
-            unquoted(),
+    winnow::trace!(
+        "gt_files",
+        repeat_array(lift(
+            alt((
+                quoted('"'), //
+                unquoted(),
+            ))
+            .and_then(alt((
+                literal("wildcard").map(|_| GTFile::Wildcard),
+                filename("gt").map(GTFile::Path),
+            ))),
         ))
-        .and_then(alt((
-            literal("wildcard").map(|_| GTFile::Wildcard),
-            filename("gt").map(GTFile::Path),
-        ))),
-    )))
+    )
 }
 
 fn num_line<'a>() -> impl WinnowParser<&'a str, NumLine> {
-    winnow::trace!("num_line", (
-        U,
-        P(space1, U),
-        P(space1, parse_bool),
-        opt(P(space1, parse_bool)),
-        opt(P(space1, parse_bool)),
-        opt(P(space1, parse_bool)),
+    winnow::trace!(
+        "num_line",
+        (
+            U,
+            P(space1, U),
+            P(space1, parse_bool),
+            opt(P(space1, parse_bool)),
+            opt(P(space1, parse_bool)),
+            opt(P(space1, parse_bool)),
+        )
+            .map(|(uint1, uint2, bool1, bool2, bool3, bool4)| NumLine {
+                uint1,
+                uint2,
+                bool1,
+                bool2,
+                bool3,
+                bool4,
+            })
     )
-        .map(|(uint1, uint2, bool1, bool2, bool3, bool4)| NumLine {
-            uint1,
-            uint2,
-            bool1,
-            bool2,
-            bool3,
-            bool4,
-        }))
 }
 
 fn virtual_et_file<'a>() -> impl WinnowParser<&'a str, VirtualETFile> {
-    winnow::trace!("virtual_et_file", separated_pair(
-        unquoted().and_then(filename("et")), //
-        space1,
-        parse_bool,
+    winnow::trace!(
+        "virtual_et_file",
+        separated_pair(
+            unquoted().and_then(filename("et")), //
+            space1,
+            parse_bool,
+        )
+        .map(|(path, bool1)| VirtualETFile { path, bool1 })
     )
-    .map(|(path, bool1)| VirtualETFile { path, bool1 }))
 }
 
 fn virtual_section<'a>() -> impl SliceParser<'a, &'a str, VirtualSection> {
-    winnow::trace!("virtual_section", (
-        lift(literal("virtual")),
-        repeat_array(lift(virtual_et_file())),
-        lift(separated_array(space1, U)),
+    winnow::trace!(
+        "virtual_section",
+        (
+            lift(literal("virtual")),
+            repeat_array(lift(virtual_et_file())),
+            lift(separated_array(space1, U)),
+        )
+            .map(
+                |(_virtual_tag, virtual_et_files, virtual_rotations)| VirtualSection {
+                    virtual_et_files,
+                    virtual_rotations,
+                },
+            )
     )
-        .map(
-            |(_virtual_tag, virtual_et_files, virtual_rotations)| VirtualSection {
-                virtual_et_files,
-                virtual_rotations,
-            },
-        ))
 }
 
 pub fn parse_et_str(contents: &str) -> Result<ETFile> {

--- a/src/file_parsers/gcf/parser.rs
+++ b/src/file_parsers/gcf/parser.rs
@@ -8,8 +8,11 @@ use crate::file_parsers::shared::{
 };
 
 fn combination<'a>() -> impl WinnowParser<&'a str, GcfCombination> {
-    winnow::trace!("combination", separated_array(space1, quoted('"').and_then(filename("gt")))
-        .map(|gt_files| GcfCombination { gt_files }))
+    winnow::trace!(
+        "combination",
+        separated_array(space1, quoted('"').and_then(filename("gt")))
+            .map(|gt_files| GcfCombination { gt_files })
+    )
 }
 
 pub fn parse_gcf_str(contents: &str) -> Result<GcfFile> {

--- a/src/file_parsers/gcf/parser.rs
+++ b/src/file_parsers/gcf/parser.rs
@@ -4,13 +4,12 @@ use winnow::{Parser, ascii::space1, combinator::repeat};
 use super::types::*;
 use crate::file_parsers::shared::{
     lift::lift,
-    winnow::{TraceHelper, WinnowParser, filename, quoted, separated_array, version_line},
+    winnow::{WinnowParser, filename, quoted, separated_array, version_line},
 };
 
 fn combination<'a>() -> impl WinnowParser<&'a str, GcfCombination> {
-    separated_array(space1, quoted('"').and_then(filename("gt")))
-        .map(|gt_files| GcfCombination { gt_files })
-        .trace("combination")
+    winnow::trace!("combination", separated_array(space1, quoted('"').and_then(filename("gt")))
+        .map(|gt_files| GcfCombination { gt_files }))
 }
 
 pub fn parse_gcf_str(contents: &str) -> Result<GcfFile> {

--- a/src/file_parsers/gft/parser.rs
+++ b/src/file_parsers/gft/parser.rs
@@ -8,38 +8,41 @@ use winnow::{
 use super::types::*;
 use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
-    winnow::{
-        TraceHelper, WinnowParser, filename, quoted, quoted_str, uint as U, unquoted_str,
-        version_line,
-    },
+    winnow::{WinnowParser, filename, quoted, quoted_str, uint as U, unquoted_str, version_line},
 };
 
 fn file<'a>() -> impl WinnowParser<&'a str, GenFile> {
-    winnow::trace!("file", (
-        U,
-        preceded(
-            space1,
-            quoted('"').and_then(alt((
-                filename("arm"), //
-                filename("tdt"),
-            ))),
-        ),
-        repeat(0.., preceded(space1, unquoted_str)),
+    winnow::trace!(
+        "file",
+        (
+            U,
+            preceded(
+                space1,
+                quoted('"').and_then(alt((
+                    filename("arm"), //
+                    filename("tdt"),
+                ))),
+            ),
+            repeat(0.., preceded(space1, unquoted_str)),
+        )
+            .map(|(weight, path, rotations)| GenFile {
+                weight,
+                path,
+                rotations,
+            })
     )
-        .map(|(weight, path, rotations)| GenFile {
-            weight,
-            path,
-            rotations,
-        }))
 }
 
 fn section<'a>(version: u32) -> impl SliceParser<'a, &'a str, Section> {
-    winnow::trace!("section", (
-        lift((quoted_str, opt(preceded(space1, U)))).trace("header"),
-        cond(version == 1, lift(U)).trace("file_count"),
-        repeat(0.., lift(file())).trace("files"),
+    winnow::trace!(
+        "section",
+        (
+            winnow::trace!("header", lift((quoted_str, opt(preceded(space1, U))))),
+            winnow::trace!("file_count", cond(version == 1, lift(U))),
+            winnow::trace!("files", repeat(0.., lift(file()))),
+        )
+            .map(|((name, uint1), _, files)| Section { name, files, uint1 })
     )
-        .map(|((name, uint1), _, files)| Section { name, files, uint1 }))
 }
 
 pub fn parse_gft_str(contents: &str) -> Result<GFTFile> {

--- a/src/file_parsers/gft/parser.rs
+++ b/src/file_parsers/gft/parser.rs
@@ -15,7 +15,7 @@ use crate::file_parsers::shared::{
 };
 
 fn file<'a>() -> impl WinnowParser<&'a str, GenFile> {
-    (
+    winnow::trace!("file", (
         U,
         preceded(
             space1,
@@ -30,18 +30,16 @@ fn file<'a>() -> impl WinnowParser<&'a str, GenFile> {
             weight,
             path,
             rotations,
-        })
-        .trace("file")
+        }))
 }
 
 fn section<'a>(version: u32) -> impl SliceParser<'a, &'a str, Section> {
-    (
+    winnow::trace!("section", (
         lift((quoted_str, opt(preceded(space1, U)))).trace("header"),
         cond(version == 1, lift(U)).trace("file_count"),
         repeat(0.., lift(file())).trace("files"),
     )
-        .map(|((name, uint1), _, files)| Section { name, files, uint1 })
-        .trace("section")
+        .map(|((name, uint1), _, files)| Section { name, files, uint1 }))
 }
 
 pub fn parse_gft_str(contents: &str) -> Result<GFTFile> {

--- a/src/file_parsers/gt/parser.rs
+++ b/src/file_parsers/gt/parser.rs
@@ -13,13 +13,16 @@ use crate::file_parsers::shared::{
 
 fn bools<'a>() -> impl WinnowParser<&'a str, (bool, bool, Option<bool>, Option<bool>, Option<bool>)>
 {
-    winnow::trace!("bools", (
-        parse_bool,
-        P(space1, parse_bool),
-        opt(P(space1, parse_bool)),
-        opt(P(space1, parse_bool)),
-        opt(P(space1, parse_bool)),
-    ))
+    winnow::trace!(
+        "bools",
+        (
+            parse_bool,
+            P(space1, parse_bool),
+            opt(P(space1, parse_bool)),
+            opt(P(space1, parse_bool)),
+            opt(P(space1, parse_bool)),
+        )
+    )
 }
 
 pub fn parse_gt_str(contents: &str) -> Result<GTFile> {

--- a/src/file_parsers/gt/parser.rs
+++ b/src/file_parsers/gt/parser.rs
@@ -8,19 +8,18 @@ use winnow::{
 use super::types::*;
 use crate::file_parsers::shared::{
     lift::lift,
-    winnow::{TraceHelper, WinnowParser, parse_bool, quoted_str, unquoted_str},
+    winnow::{WinnowParser, parse_bool, quoted_str, unquoted_str},
 };
 
 fn bools<'a>() -> impl WinnowParser<&'a str, (bool, bool, Option<bool>, Option<bool>, Option<bool>)>
 {
-    (
+    winnow::trace!("bools", (
         parse_bool,
         P(space1, parse_bool),
         opt(P(space1, parse_bool)),
         opt(P(space1, parse_bool)),
         opt(P(space1, parse_bool)),
-    )
-        .trace("bools")
+    ))
 }
 
 pub fn parse_gt_str(contents: &str) -> Result<GTFile> {

--- a/src/file_parsers/mtd/parser.rs
+++ b/src/file_parsers/mtd/parser.rs
@@ -11,38 +11,47 @@ use crate::file_parsers::shared::winnow::{
 };
 
 fn entry(contents: &mut &str) -> winnow::Result<Entry> {
-    winnow::trace!("entry", (
-        quoted('"').and_then(filename("mat")),
-        repeat(
-            0..,
-            P(
-                // NOTE Edge case: Missing space between strings here
-                space0, //
-                quoted('"').and_then(filename("dlp")),
+    winnow::trace!(
+        "entry",
+        (
+            quoted('"').and_then(filename("mat")),
+            repeat(
+                0..,
+                P(
+                    // NOTE Edge case: Missing space between strings here
+                    space0, //
+                    quoted('"').and_then(filename("dlp")),
+                ),
             ),
-        ),
+        )
+            .map(|(mat_file, dlp_files)| Entry {
+                mat_file,
+                dlp_files,
+            })
     )
-        .map(|(mat_file, dlp_files)| Entry {
-            mat_file,
-            dlp_files,
-        }))
-        .parse_next(contents)
+    .parse_next(contents)
 }
 
 fn weights_line<'a>(num_weights: usize) -> impl WinnowParser<&'a str, (Vec<u32>, u32)> {
-    winnow::trace!("weights_line", (
-        separated(num_weights, dec_uint::<_, u32, _>, S()), //
-        P(S(), dec_uint),
-    ))
+    winnow::trace!(
+        "weights_line",
+        (
+            separated(num_weights, dec_uint::<_, u32, _>, S()), //
+            P(S(), dec_uint),
+        )
+    )
 }
 
 fn group(contents: &mut &str) -> winnow::Result<Group> {
-    let (name, num_a, num_b) = winnow::trace!("group_header", (
-        opt(terminated(quoted_str, S())),
-        dec_uint,
-        P(S(), dec_uint::<_, usize, _>),
-    ))
-        .parse_next(contents)?;
+    let (name, num_a, num_b) = winnow::trace!(
+        "group_header",
+        (
+            opt(terminated(quoted_str, S())),
+            dec_uint,
+            P(S(), dec_uint::<_, usize, _>),
+        )
+    )
+    .parse_next(contents)?;
 
     let entries = repeat(num_a, P(S(), entry)).parse_next(contents)?;
 

--- a/src/file_parsers/mtd/parser.rs
+++ b/src/file_parsers/mtd/parser.rs
@@ -7,11 +7,11 @@ use winnow::{
 
 use super::{super::shared::winnow::spaces_or_comments as S, types::*};
 use crate::file_parsers::shared::winnow::{
-    TraceHelper, WinnowParser, filename, parse_bool, quoted, quoted_str, version_line,
+    WinnowParser, filename, parse_bool, quoted, quoted_str, version_line,
 };
 
 fn entry(contents: &mut &str) -> winnow::Result<Entry> {
-    (
+    winnow::trace!("entry", (
         quoted('"').and_then(filename("mat")),
         repeat(
             0..,
@@ -25,26 +25,23 @@ fn entry(contents: &mut &str) -> winnow::Result<Entry> {
         .map(|(mat_file, dlp_files)| Entry {
             mat_file,
             dlp_files,
-        })
-        .trace("entry")
+        }))
         .parse_next(contents)
 }
 
 fn weights_line<'a>(num_weights: usize) -> impl WinnowParser<&'a str, (Vec<u32>, u32)> {
-    (
+    winnow::trace!("weights_line", (
         separated(num_weights, dec_uint::<_, u32, _>, S()), //
         P(S(), dec_uint),
-    )
-        .trace("weights_line")
+    ))
 }
 
 fn group(contents: &mut &str) -> winnow::Result<Group> {
-    let (name, num_a, num_b) = (
+    let (name, num_a, num_b) = winnow::trace!("group_header", (
         opt(terminated(quoted_str, S())),
         dec_uint,
         P(S(), dec_uint::<_, usize, _>),
-    )
-        .trace("group_header")
+    ))
         .parse_next(contents)?;
 
     let entries = repeat(num_a, P(S(), entry)).parse_next(contents)?;

--- a/src/file_parsers/pet/parser.rs
+++ b/src/file_parsers/pet/parser.rs
@@ -14,21 +14,24 @@ use crate::file_parsers::shared::{
 };
 
 fn emitter<'a>() -> impl SliceParser<'a, &'a str, Emitter> {
-    winnow::trace!("emitter", (
-        lift(literal("{")), //
-        lift(unquoted_str),
-        lift(quoted('"').and_then(optional_filename("mat"))),
-        repeat_till::<_, _, Vec<_>, _, _, _, _>(
-            .., //
-            lift(rest),
-            lift(literal("}")),
-        ),
+    winnow::trace!(
+        "emitter",
+        (
+            lift(literal("{")), //
+            lift(unquoted_str),
+            lift(quoted('"').and_then(optional_filename("mat"))),
+            repeat_till::<_, _, Vec<_>, _, _, _, _>(
+                .., //
+                lift(rest),
+                lift(literal("}")),
+            ),
+        )
+            .map(|(_, emitter_type, material, (contents, _))| Emitter {
+                emitter_type,
+                material,
+                key_values: contents.join("\n"),
+            })
     )
-        .map(|(_, emitter_type, material, (contents, _))| Emitter {
-            emitter_type,
-            material,
-            key_values: contents.join("\n"),
-        }))
 }
 
 pub fn parse_pet_str(contents: &str) -> Result<PETFile> {

--- a/src/file_parsers/pet/parser.rs
+++ b/src/file_parsers/pet/parser.rs
@@ -10,11 +10,11 @@ use winnow::{
 use super::types::*;
 use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
-    winnow::{TraceHelper, optional_filename, quoted, unquoted_str, version_line},
+    winnow::{optional_filename, quoted, unquoted_str, version_line},
 };
 
 fn emitter<'a>() -> impl SliceParser<'a, &'a str, Emitter> {
-    (
+    winnow::trace!("emitter", (
         lift(literal("{")), //
         lift(unquoted_str),
         lift(quoted('"').and_then(optional_filename("mat"))),
@@ -28,8 +28,7 @@ fn emitter<'a>() -> impl SliceParser<'a, &'a str, Emitter> {
             emitter_type,
             material,
             key_values: contents.join("\n"),
-        })
-        .trace("emitter")
+        }))
 }
 
 pub fn parse_pet_str(contents: &str) -> Result<PETFile> {

--- a/src/file_parsers/psg/parser.rs
+++ b/src/file_parsers/psg/parser.rs
@@ -6,22 +6,21 @@ use winnow::{
 };
 
 use super::types::*;
-use crate::file_parsers::shared::winnow::{TraceHelper, WinnowParser};
+use crate::file_parsers::shared::winnow::WinnowParser;
 
 fn connection<'a>(poe_version: u32) -> impl WinnowParser<&'a [u8], Connection> {
-    (
+    winnow::trace!("connection", (
         le_u32, //
         cond(poe_version == 2, le_i32),
     )
         .map(|(passive_id, curvature)| Connection {
             passive_id,
             curvature,
-        })
-        .trace("connection")
+        }))
 }
 
 fn passive<'a>(poe_version: u32) -> impl WinnowParser<&'a [u8], Passive> {
-    (
+    winnow::trace!("passive", (
         le_u32,
         le_i32,
         le_u32,
@@ -32,12 +31,11 @@ fn passive<'a>(poe_version: u32) -> impl WinnowParser<&'a [u8], Passive> {
             orbit,
             orbit_position,
             connections,
-        })
-        .trace("passive")
+        }))
 }
 
 fn group<'a>(poe_version: u32) -> impl WinnowParser<&'a [u8], Group> {
-    (
+    winnow::trace!("group", (
         le_f32,
         le_f32,
         le_u32,
@@ -52,8 +50,7 @@ fn group<'a>(poe_version: u32) -> impl WinnowParser<&'a [u8], Group> {
             unk1,
             unk2,
             passives,
-        })
-        .trace("group")
+        }))
 }
 
 pub fn parse_psg_bytes(contents: &[u8], poe_version: u32) -> Result<PSGFile> {

--- a/src/file_parsers/psg/parser.rs
+++ b/src/file_parsers/psg/parser.rs
@@ -9,48 +9,57 @@ use super::types::*;
 use crate::file_parsers::shared::winnow::WinnowParser;
 
 fn connection<'a>(poe_version: u32) -> impl WinnowParser<&'a [u8], Connection> {
-    winnow::trace!("connection", (
-        le_u32, //
-        cond(poe_version == 2, le_i32),
+    winnow::trace!(
+        "connection",
+        (
+            le_u32, //
+            cond(poe_version == 2, le_i32),
+        )
+            .map(|(passive_id, curvature)| Connection {
+                passive_id,
+                curvature,
+            })
     )
-        .map(|(passive_id, curvature)| Connection {
-            passive_id,
-            curvature,
-        }))
 }
 
 fn passive<'a>(poe_version: u32) -> impl WinnowParser<&'a [u8], Passive> {
-    winnow::trace!("passive", (
-        le_u32,
-        le_i32,
-        le_u32,
-        length_repeat(le_u32, connection(poe_version)),
+    winnow::trace!(
+        "passive",
+        (
+            le_u32,
+            le_i32,
+            le_u32,
+            length_repeat(le_u32, connection(poe_version)),
+        )
+            .map(|(id, orbit, orbit_position, connections)| Passive {
+                id,
+                orbit,
+                orbit_position,
+                connections,
+            })
     )
-        .map(|(id, orbit, orbit_position, connections)| Passive {
-            id,
-            orbit,
-            orbit_position,
-            connections,
-        }))
 }
 
 fn group<'a>(poe_version: u32) -> impl WinnowParser<&'a [u8], Group> {
-    winnow::trace!("group", (
-        le_f32,
-        le_f32,
-        le_u32,
-        le_u32,
-        le_u8,
-        length_repeat(le_u32, passive(poe_version)),
+    winnow::trace!(
+        "group",
+        (
+            le_f32,
+            le_f32,
+            le_u32,
+            le_u32,
+            le_u8,
+            length_repeat(le_u32, passive(poe_version)),
+        )
+            .map(|(x, y, flags, unk1, unk2, passives)| Group {
+                x,
+                y,
+                flags,
+                unk1,
+                unk2,
+                passives,
+            })
     )
-        .map(|(x, y, flags, unk1, unk2, passives)| Group {
-            x,
-            y,
-            flags,
-            unk1,
-            unk2,
-            passives,
-        }))
 }
 
 pub fn parse_psg_bytes(contents: &[u8], poe_version: u32) -> Result<PSGFile> {

--- a/src/file_parsers/rs/parser.rs
+++ b/src/file_parsers/rs/parser.rs
@@ -8,11 +8,11 @@ use winnow::{
 use super::types::*;
 use crate::file_parsers::shared::{
     lift::lift,
-    winnow::{TraceHelper, WinnowParser, filename, quoted, uint, unquoted_str, version_line},
+    winnow::{WinnowParser, filename, quoted, uint, unquoted_str, version_line},
 };
 
 fn room<'a>() -> impl WinnowParser<&'a str, Room> {
-    (
+    winnow::trace!("room", (
         opt(terminated(uint, space0)),
         quoted('"').and_then(filename("arm")),
         repeat(0.., preceded(space1, unquoted_str)),
@@ -21,8 +21,7 @@ fn room<'a>() -> impl WinnowParser<&'a str, Room> {
             weight,
             arm_file,
             rotations,
-        })
-        .trace("room")
+        }))
 }
 
 pub fn parse_rs_str(contents: &str) -> Result<RSFile> {

--- a/src/file_parsers/rs/parser.rs
+++ b/src/file_parsers/rs/parser.rs
@@ -12,16 +12,19 @@ use crate::file_parsers::shared::{
 };
 
 fn room<'a>() -> impl WinnowParser<&'a str, Room> {
-    winnow::trace!("room", (
-        opt(terminated(uint, space0)),
-        quoted('"').and_then(filename("arm")),
-        repeat(0.., preceded(space1, unquoted_str)),
+    winnow::trace!(
+        "room",
+        (
+            opt(terminated(uint, space0)),
+            quoted('"').and_then(filename("arm")),
+            repeat(0.., preceded(space1, unquoted_str)),
+        )
+            .map(|(weight, arm_file, rotations)| Room {
+                weight,
+                arm_file,
+                rotations,
+            })
     )
-        .map(|(weight, arm_file, rotations)| Room {
-            weight,
-            arm_file,
-            rotations,
-        }))
 }
 
 pub fn parse_rs_str(contents: &str) -> Result<RSFile> {

--- a/src/file_parsers/shared/lift.rs
+++ b/src/file_parsers/shared/lift.rs
@@ -5,8 +5,6 @@ use winnow::{
     stream::{Stream, StreamIsPartial},
 };
 
-use crate::file_parsers::shared::winnow::TraceHelper;
-
 /// Winnow parser over `&[I]` input
 pub trait SliceParser<'a, I, O> = Parser<&'a [I], O, ContextError> where I: 'a;
 
@@ -58,7 +56,7 @@ where
     S: Stream<Token = I>,
     P: Parser<I, O, ContextError>,
 {
-    Lift::new(parser).trace("lift")
+    winnow::trace!("lift", Lift::new(parser))
 }
 
 #[cfg(test)]

--- a/src/file_parsers/shared/winnow.rs
+++ b/src/file_parsers/shared/winnow.rs
@@ -1,10 +1,8 @@
-use std::fmt::Display;
-
 use winnow::{
     Parser,
     ascii::{dec_int, dec_uint},
     combinator::{alt, delimited, eof, preceded, repeat, separated, trace},
-    error::{ContextError, ParserError},
+    error::ContextError,
     stream::{AsChar, Stream},
     token::{literal, rest, take_till, take_until, take_while},
 };
@@ -23,7 +21,7 @@ pub fn parse_bool(input: &mut &str) -> winnow::Result<bool> {
         }
     };
 
-    parser.trace("parse_bool").parse_next(input)
+    winnow::trace!("parse_bool", parser).parse_next(input)
 }
 
 /// Parses a u32, ensuring that it hasn't just parsed the first digit of what's actually a float
@@ -38,7 +36,7 @@ pub fn safe_u32(input: &mut &str) -> winnow::Result<u32> {
         }
     };
 
-    parser.trace("safe_u32").parse_next(input)
+    winnow::trace!("safe_u32", parser).parse_next(input)
 }
 
 /// Winnow's dec_uint has issues with leading 0's, so manual impl here
@@ -47,128 +45,144 @@ pub fn safe_u32(input: &mut &str) -> winnow::Result<u32> {
 /// "1000" => 1000
 /// "0010" => 10
 pub fn uint(input: &mut &str) -> winnow::Result<u32> {
-    take_while(1.., AsChar::is_dec_digit)
-        .try_map(|x: &str| x.parse::<u32>())
-        .trace("uint")
-        .parse_next(input)
+    winnow::trace!(
+        "uint",
+        take_while(1.., AsChar::is_dec_digit).try_map(|x: &str| x.parse::<u32>())
+    )
+    .parse_next(input)
 }
 
 /// -1 or 0+
 pub fn nullable_uint<'a>() -> impl WinnowParser<&'a str, Option<u32>> {
-    dec_int
-        .map(|i: i32| match i {
+    winnow::trace!(
+        "nullable_uint",
+        dec_int.map(|i: i32| match i {
             -1 => None,
             0.. => Some(i as u32),
             _ => unreachable!("-1 or 0+ expected"),
         })
-        .trace("nullable_uint")
+    )
 }
 
 /// " \t\r\n" - at least 1
 pub fn space_or_nl1<'a>(input: &mut &'a str) -> winnow::Result<&'a str> {
-    take_while(1.., |c: char| {
-        c == ' ' || c == '\t' || c == '\r' || c == '\n'
-    })
-    .trace("space_or_nl1")
+    winnow::trace!(
+        "space_or_nl1",
+        take_while(1.., |c: char| {
+            c == ' ' || c == '\t' || c == '\r' || c == '\n'
+        })
+    )
     .parse_next(input)
 }
 
 /// " \t\r\n" - 0 or more
 pub fn space_or_nl0<'a>(input: &mut &'a str) -> winnow::Result<&'a str> {
-    take_while(0.., |c: char| {
-        c == ' ' || c == '\t' || c == '\r' || c == '\n'
-    })
-    .trace("space_or_nl0")
+    winnow::trace!(
+        "space_or_nl0",
+        take_while(0.., |c: char| {
+            c == ' ' || c == '\t' || c == '\r' || c == '\n'
+        })
+    )
     .parse_next(input)
 }
 
 /// /* multiline comments */
 pub fn comment_multiline<'a>() -> impl WinnowParser<&'a str, &'a str> {
-    delimited("/*", take_until(0.., "*/"), "*/") //
-        .trace("multiline_comment")
+    winnow::trace!(
+        "multiline_comment",
+        delimited("/*", take_until(0.., "*/"), "*/")
+    )
 }
 
 /// // Single line comment
 pub fn comment_single_line<'a>() -> impl WinnowParser<&'a str, &'a str> {
-    preceded("//", take_while(0.., |c| !(c == '\r' || c == '\n'))) //
-        .trace("single_line_comment")
+    winnow::trace!(
+        "single_line_comment",
+        preceded("//", take_while(0.., |c| !(c == '\r' || c == '\n'))) //
+    )
 }
 
 /// Some combination of spaces, newlines, or comments, at least 1
 pub fn spaces_or_comments<'a>() -> impl WinnowParser<&'a str, String> {
     let part_parser = alt((space_or_nl1, comment_multiline(), comment_single_line()));
 
-    repeat(1.., part_parser)
-        .map(|parts: Vec<&str>| parts.concat())
-        .trace("spaces_or_comments")
+    winnow::trace!(
+        "spaces_or_comments",
+        repeat(1.., part_parser).map(|parts: Vec<&str>| parts.concat())
+    )
 }
 
 pub fn quoted<'a>(quote: char) -> impl WinnowParser<&'a str, &'a str> {
-    delimited(
-        quote, //
-        take_until(0.., quote),
-        quote,
-    ) //
-    .trace(format!("quoted {quote:?}"))
+    let name = format!("{}({:?})", winnow::trace_name!("quoted"), quote);
+    trace(
+        name,
+        delimited(
+            quote, //
+            take_until(0.., quote),
+            quote,
+        ),
+    )
 }
 
 pub fn unquoted<'a>() -> impl WinnowParser<&'a str, &'a str> {
-    take_till(1.., char::is_whitespace).trace("unquoted")
+    winnow::trace!("unquoted", take_till(1.., char::is_whitespace))
 }
 
 pub fn quoted_str(input: &mut &str) -> winnow::Result<String> {
-    quoted('"')
-        .map(String::from)
-        .trace("quoted_str")
-        .parse_next(input)
+    winnow::trace!("quoted_str", quoted('"').map(String::from)).parse_next(input)
 }
 
 pub fn single_quoted_str(input: &mut &str) -> winnow::Result<String> {
-    quoted('\'')
-        .map(String::from)
-        .trace("single_quoted_str")
-        .parse_next(input)
+    winnow::trace!("single_quoted_str", quoted('\'').map(String::from)).parse_next(input)
 }
 
 pub fn unquoted_str(input: &mut &str) -> winnow::Result<String> {
-    unquoted()
-        .map(String::from)
-        .trace("unquoted_str")
-        .parse_next(input)
+    winnow::trace!("unquoted_str", unquoted().map(String::from)).parse_next(input)
 }
 
 /// Designed for use with Parser::and_then
 pub fn filename<'a>(extension: &str) -> impl WinnowParser<&'a str, String> {
     let ext = format!(".{extension}");
 
-    rest.verify(move |s: &str| s.ends_with(&ext))
-        .map(String::from)
-        .trace(format!("filename {extension:?}"))
+    let name = format!("{}({:?})", winnow::trace_name!("filename"), extension);
+    trace(
+        name,
+        rest.verify(move |s: &str| s.ends_with(&ext))
+            .map(String::from),
+    )
 }
 
 /// Filename with the provided extension, or empty string
 /// Designed for use with Parser::and_then
 pub fn optional_filename<'a>(extension: &str) -> impl WinnowParser<&'a str, Option<String>> {
-    alt((
-        eof.map(|_| None), //
-        filename(extension).map(Some),
-    ))
-    .trace(format!("optional_filename {extension:?}"))
+    let name = format!(
+        "{}({:?})",
+        winnow::trace_name!("optional_filename"),
+        extension
+    );
+    trace(
+        name,
+        alt((
+            eof.map(|_| None), //
+            filename(extension).map(Some),
+        )),
+    )
 }
 
 pub fn version_line<'a>() -> impl WinnowParser<&'a str, u32> {
-    preceded(literal("version "), dec_uint).trace("version_line")
+    winnow::trace!("version_line", preceded(literal("version "), dec_uint))
 }
 
 /// "hello, world"
 pub fn quoted_comma_separated<'a>() -> impl WinnowParser<&'a str, Vec<String>> {
-    quoted('"')
-        .and_then(separated(
+    winnow::trace!(
+        "quoted_comma_separated",
+        quoted('"').and_then(separated(
             1..,
             take_while(1.., |c| c != ',').map(String::from),
             literal(", "),
         ))
-        .trace("quoted_comma_separated")
+    )
 }
 
 /// winnow::combinator::multi::separated but exact sized
@@ -181,12 +195,13 @@ where
     P: WinnowParser<I, PO>,
     S: WinnowParser<I, SO>,
 {
-    separated(N, item, sep)
-        .map(|x: Vec<_>| {
+    winnow::trace!(
+        "separated_array",
+        separated(N, item, sep).map(|x: Vec<_>| {
             x.try_into()
                 .unwrap_or_else(|_| unreachable!("Parser should take care of length"))
         })
-        .trace("separated_array")
+    )
 }
 
 /// winnow::combinator::repeat but exact sized
@@ -196,28 +211,13 @@ pub fn repeat_array<const N: usize, I, O>(
 where
     I: Stream,
 {
-    repeat(N, parser)
-        .map(|x: Vec<_>| {
+    winnow::trace!(
+        "repeat_array",
+        repeat(N, parser).map(|x: Vec<_>| {
             x.try_into()
                 .unwrap_or_else(|_| unreachable!("Parser should take care of length"))
         })
-        .trace("repeat_array")
-}
-
-/// tail .trace()
-pub trait TraceHelper<I, O, E> {
-    fn trace(self, name: impl Display) -> impl Parser<I, O, E>;
-}
-
-impl<P, I, O, E> TraceHelper<I, O, E> for P
-where
-    I: Stream,
-    E: ParserError<I>,
-    P: Parser<I, O, E>,
-{
-    fn trace(self, name: impl Display) -> impl Parser<I, O, E> {
-        trace(name, self)
-    }
+    )
 }
 
 #[cfg(test)]

--- a/src/file_parsers/toy/parser.rs
+++ b/src/file_parsers/toy/parser.rs
@@ -9,55 +9,61 @@ use winnow::{
 use super::types::*;
 use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
-    winnow::{
-        WinnowParser, filename, parse_bool, quoted, unquoted, unquoted_str,
-        version_line,
-    },
+    winnow::{WinnowParser, filename, parse_bool, quoted, unquoted, unquoted_str, version_line},
 };
 
 /// One of: [I, R90, R180, R270, FI, FR90, FR180, FR270]
 fn d4_rotation<'a>() -> impl WinnowParser<&'a str, Rotation> {
-    winnow::trace!("d4_rotation", (
-        opt(literal('F')).map(|f| f.is_some()),
-        alt((
-            literal('I').value(0), //
-            P(literal('R'), dec_uint),
-        )),
+    winnow::trace!(
+        "d4_rotation",
+        (
+            opt(literal('F')).map(|f| f.is_some()),
+            alt((
+                literal('I').value(0), //
+                P(literal('R'), dec_uint),
+            )),
+        )
+            .map(|(flip, angle)| Rotation { flip, angle })
     )
-        .map(|(flip, angle)| Rotation { flip, angle }))
 }
 
 /// +/- followed by a flag name
 fn flag<'a>() -> impl WinnowParser<&'a str, String> {
-    winnow::trace!("flag", (
-        alt((
-            literal('+'), //
-            literal('-'),
-        )),
-        unquoted(),
+    winnow::trace!(
+        "flag",
+        (
+            alt((
+                literal('+'), //
+                literal('-'),
+            )),
+            unquoted(),
+        )
+            .map(|(prefix, name)| [prefix, name].concat())
     )
-        .map(|(prefix, name)| [prefix, name].concat()))
 }
 
 fn header<'a>() -> impl WinnowParser<&'a str, Header> {
-    winnow::trace!("header", (
-        parse_bool,
-        P(space1, parse_bool),
-        opt(P(
-            space1,
-            alt((
-                literal("FileOrder").value(Order::File),
-                literal("SizeOrder").value(Order::Size),
+    winnow::trace!(
+        "header",
+        (
+            parse_bool,
+            P(space1, parse_bool),
+            opt(P(
+                space1,
+                alt((
+                    literal("FileOrder").value(Order::File),
+                    literal("SizeOrder").value(Order::Size),
+                )),
             )),
-        )),
-        repeat(0.., P(space1, flag())),
+            repeat(0.., P(space1, flag())),
+        )
+            .map(|(uint1, uint2, file_order, flags)| Header {
+                bool1: uint1,
+                bool2: uint2,
+                file_order,
+                flags,
+            })
     )
-        .map(|(uint1, uint2, file_order, flags)| Header {
-            bool1: uint1,
-            bool2: uint2,
-            file_order,
-            flags,
-        }))
 }
 
 fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
@@ -106,28 +112,34 @@ fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
         },
     );
 
-    winnow::trace!("entry", (
-        primary_stuff, //
-        tail_stuff,
+    winnow::trace!(
+        "entry",
+        (
+            primary_stuff, //
+            tail_stuff,
+        )
+            .map(
+                |((weight, arm_file), (key_values, not_flags, add_flags, rotations))| Entry {
+                    weight,
+                    arm_file,
+                    key_values,
+                    not_flags,
+                    add_flags,
+                    rotations,
+                },
+            )
     )
-        .map(
-            |((weight, arm_file), (key_values, not_flags, add_flags, rotations))| Entry {
-                weight,
-                arm_file,
-                key_values,
-                not_flags,
-                add_flags,
-                rotations,
-            },
-        ))
 }
 
 fn group<'a>() -> impl SliceParser<'a, &'a str, Group> {
-    winnow::trace!("group", (
-        lift(header()), //
-        repeat(0.., lift(entry())),
+    winnow::trace!(
+        "group",
+        (
+            lift(header()), //
+            repeat(0.., lift(entry())),
+        )
+            .map(|(header, entries)| Group { header, entries })
     )
-        .map(|(header, entries)| Group { header, entries }))
 }
 
 pub fn parse_toy_str(contents: &str) -> Result<TOYFile> {

--- a/src/file_parsers/toy/parser.rs
+++ b/src/file_parsers/toy/parser.rs
@@ -10,39 +10,37 @@ use super::types::*;
 use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
     winnow::{
-        TraceHelper, WinnowParser, filename, parse_bool, quoted, unquoted, unquoted_str,
+        WinnowParser, filename, parse_bool, quoted, unquoted, unquoted_str,
         version_line,
     },
 };
 
 /// One of: [I, R90, R180, R270, FI, FR90, FR180, FR270]
 fn d4_rotation<'a>() -> impl WinnowParser<&'a str, Rotation> {
-    (
+    winnow::trace!("d4_rotation", (
         opt(literal('F')).map(|f| f.is_some()),
         alt((
             literal('I').value(0), //
             P(literal('R'), dec_uint),
         )),
     )
-        .map(|(flip, angle)| Rotation { flip, angle })
-        .trace("d4_rotation")
+        .map(|(flip, angle)| Rotation { flip, angle }))
 }
 
 /// +/- followed by a flag name
 fn flag<'a>() -> impl WinnowParser<&'a str, String> {
-    (
+    winnow::trace!("flag", (
         alt((
             literal('+'), //
             literal('-'),
         )),
         unquoted(),
     )
-        .map(|(prefix, name)| [prefix, name].concat())
-        .trace("flag")
+        .map(|(prefix, name)| [prefix, name].concat()))
 }
 
 fn header<'a>() -> impl WinnowParser<&'a str, Header> {
-    (
+    winnow::trace!("header", (
         parse_bool,
         P(space1, parse_bool),
         opt(P(
@@ -59,8 +57,7 @@ fn header<'a>() -> impl WinnowParser<&'a str, Header> {
             bool2: uint2,
             file_order,
             flags,
-        })
-        .trace("header")
+        }))
 }
 
 fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
@@ -109,7 +106,7 @@ fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
         },
     );
 
-    (
+    winnow::trace!("entry", (
         primary_stuff, //
         tail_stuff,
     )
@@ -122,17 +119,15 @@ fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
                 add_flags,
                 rotations,
             },
-        )
-        .trace("entry")
+        ))
 }
 
 fn group<'a>() -> impl SliceParser<'a, &'a str, Group> {
-    (
+    winnow::trace!("group", (
         lift(header()), //
         repeat(0.., lift(entry())),
     )
-        .map(|(header, entries)| Group { header, entries })
-        .trace("group")
+        .map(|(header, entries)| Group { header, entries }))
 }
 
 pub fn parse_toy_str(contents: &str) -> Result<TOYFile> {

--- a/src/file_parsers/trl/parser.rs
+++ b/src/file_parsers/trl/parser.rs
@@ -13,15 +13,18 @@ use crate::file_parsers::shared::{
 };
 
 fn emitter<'a>() -> impl SliceParser<'a, &'a str, Emitter> {
-    winnow::trace!("emitter", (
-        lift(literal("{")), //
-        repeat_till::<_, _, Vec<_>, _, _, _, _>(
-            .., //
-            lift(separated_pair(unquoted_str, space1, rest.map(String::from))),
-            lift(literal("}")),
-        ),
+    winnow::trace!(
+        "emitter",
+        (
+            lift(literal("{")), //
+            repeat_till::<_, _, Vec<_>, _, _, _, _>(
+                .., //
+                lift(separated_pair(unquoted_str, space1, rest.map(String::from))),
+                lift(literal("}")),
+            ),
+        )
+            .map(|(_, (key_values, _))| Emitter::from_iter(key_values))
     )
-        .map(|(_, (key_values, _))| Emitter::from_iter(key_values)))
 }
 
 pub fn parse_trl_str(contents: &str) -> Result<TRLFile> {

--- a/src/file_parsers/trl/parser.rs
+++ b/src/file_parsers/trl/parser.rs
@@ -9,11 +9,11 @@ use winnow::{
 use super::types::*;
 use crate::file_parsers::shared::{
     lift::{SliceParser, lift},
-    winnow::{TraceHelper, unquoted_str, version_line},
+    winnow::{unquoted_str, version_line},
 };
 
 fn emitter<'a>() -> impl SliceParser<'a, &'a str, Emitter> {
-    (
+    winnow::trace!("emitter", (
         lift(literal("{")), //
         repeat_till::<_, _, Vec<_>, _, _, _, _>(
             .., //
@@ -21,8 +21,7 @@ fn emitter<'a>() -> impl SliceParser<'a, &'a str, Emitter> {
             lift(literal("}")),
         ),
     )
-        .map(|(_, (key_values, _))| Emitter::from_iter(key_values))
-        .trace("emitter")
+        .map(|(_, (key_values, _))| Emitter::from_iter(key_values)))
 }
 
 pub fn parse_trl_str(contents: &str) -> Result<TRLFile> {

--- a/src/file_parsers/tsi/parser.rs
+++ b/src/file_parsers/tsi/parser.rs
@@ -13,15 +13,18 @@ use crate::file_parsers::shared::{
 };
 
 fn key_value<'a>() -> impl WinnowParser<&'a str, (String, String)> {
-    winnow::trace!("key_value", separated_pair(
-        unquoted_str,
-        space1,
-        // Attempt to un-quote single quoted strings, otherwise just take the rest as-is
-        alt((
-            terminated(quoted_str, eof), //
-            rest.map(String::from),
-        )),
-    ))
+    winnow::trace!(
+        "key_value",
+        separated_pair(
+            unquoted_str,
+            space1,
+            // Attempt to un-quote single quoted strings, otherwise just take the rest as-is
+            alt((
+                terminated(quoted_str, eof), //
+                rest.map(String::from),
+            )),
+        )
+    )
 }
 
 pub fn parse_tsi_str(contents: &str) -> Result<TSIFile> {

--- a/src/file_parsers/tsi/parser.rs
+++ b/src/file_parsers/tsi/parser.rs
@@ -9,11 +9,11 @@ use winnow::{
 use super::types::TSIFile;
 use crate::file_parsers::shared::{
     lift::lift,
-    winnow::{TraceHelper, WinnowParser, quoted_str, unquoted_str},
+    winnow::{WinnowParser, quoted_str, unquoted_str},
 };
 
 fn key_value<'a>() -> impl WinnowParser<&'a str, (String, String)> {
-    separated_pair(
+    winnow::trace!("key_value", separated_pair(
         unquoted_str,
         space1,
         // Attempt to un-quote single quoted strings, otherwise just take the rest as-is
@@ -21,8 +21,7 @@ fn key_value<'a>() -> impl WinnowParser<&'a str, (String, String)> {
             terminated(quoted_str, eof), //
             rest.map(String::from),
         )),
-    )
-    .trace("key_value")
+    ))
 }
 
 pub fn parse_tsi_str(contents: &str) -> Result<TSIFile> {

--- a/src/file_parsers/tst/parser.rs
+++ b/src/file_parsers/tst/parser.rs
@@ -12,17 +12,20 @@ use crate::file_parsers::shared::{
 };
 
 fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
-    winnow::trace!("entry", (
-        // NOTE: Edge case: missing space between weight & filename
-        opt(terminated(dec_uint, space0)), //
-        quoted('"').and_then(filename("tdt")),
-        repeat(0.., preceded(space1, unquoted_str)),
+    winnow::trace!(
+        "entry",
+        (
+            // NOTE: Edge case: missing space between weight & filename
+            opt(terminated(dec_uint, space0)), //
+            quoted('"').and_then(filename("tdt")),
+            repeat(0.., preceded(space1, unquoted_str)),
+        )
+            .map(|(weight, tdt_file, rotations)| Entry {
+                weight,
+                tdt_file,
+                rotations,
+            })
     )
-        .map(|(weight, tdt_file, rotations)| Entry {
-            weight,
-            tdt_file,
-            rotations,
-        }))
 }
 
 pub fn parse_tst_str(contents: &str) -> Result<TSTFile> {

--- a/src/file_parsers/tst/parser.rs
+++ b/src/file_parsers/tst/parser.rs
@@ -8,11 +8,11 @@ use winnow::{
 use super::types::*;
 use crate::file_parsers::shared::{
     lift::lift,
-    winnow::{TraceHelper, WinnowParser, filename, quoted, unquoted_str},
+    winnow::{WinnowParser, filename, quoted, unquoted_str},
 };
 
 fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
-    (
+    winnow::trace!("entry", (
         // NOTE: Edge case: missing space between weight & filename
         opt(terminated(dec_uint, space0)), //
         quoted('"').and_then(filename("tdt")),
@@ -22,8 +22,7 @@ fn entry<'a>() -> impl WinnowParser<&'a str, Entry> {
             weight,
             tdt_file,
             rotations,
-        })
-        .trace("entry")
+        }))
 }
 
 pub fn parse_tst_str(contents: &str) -> Result<TSTFile> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 #![feature(trait_alias)]
 #![feature(str_from_utf16_endian)]
-#![feature(closure_lifetime_binder)]
-#![feature(string_from_utf8_lossy_owned)]
 use std::sync::OnceLock;
 
 pub mod bundle;

--- a/src/tree/passive_info.rs
+++ b/src/tree/passive_info.rs
@@ -12,7 +12,7 @@ use serde::Serialize;
 
 use crate::{
     bundle_fs::FS,
-    commands::{Patch, dump_tables::load_parsed_table},
+    commands::{Patch, dump_tables_csv::load_parsed_table},
     dat::ivy_schema::fetch_schema,
 };
 


### PR DESCRIPTION
Adds a new `--mode=csv/json` option to the `dump-tables` command. Defaults to `csv` which is the existing functionality.  
`json` mode exports the tables as JSON. The output tries to be as error-recoverable as possible, replacing bad schema-inferred values with `null`, and bad references with their `rowIndex`.  
The output is designed to be compact and consistent so that diffing across different game versions produces a clear comparison.  

Also includes improved winnow tracing which can be controlled using the `WINNOW_TRACE` env variable
